### PR TITLE
Database encoding and Locator clarity

### DIFF
--- a/cid/encoding.go
+++ b/cid/encoding.go
@@ -1,7 +1,9 @@
 package cid
 
 import (
+	"database/sql/driver"
 	"encoding/json"
+	"fmt"
 	"strings"
 )
 
@@ -24,5 +26,24 @@ func (c *ContentID) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	*c = cid
+	return nil
+}
+
+// Value implements database/sql
+func (c ContentID) Value() (driver.Value, error) {
+	return []byte(c.String()), nil
+}
+
+// Scan implements database/sql
+func (c *ContentID) Scan(data interface{}) error {
+	v, ok := data.([]byte)
+	if !ok {
+		return fmt.Errorf("ContentID did not get bytes: %#v", data)
+	}
+	o, err := Parse(string(v))
+	if err != nil {
+		return err
+	}
+	*c = o
 	return nil
 }

--- a/cid/encoding_test.go
+++ b/cid/encoding_test.go
@@ -69,3 +69,22 @@ func TestCIDJSON(t *testing.T) {
 		}
 	}
 }
+
+func TestCIDDatabase(t *testing.T) {
+	cidIn := NewLiteral("abc")
+	val, err := cidIn.Value()
+	if err != nil {
+		t.Fatalf("Value() failed: %s", err)
+	}
+	_, ok := val.([]byte)
+	if !ok {
+		t.Fatalf("Value() did not return bytes")
+	}
+	cidOut := &ContentID{}
+	if err := cidOut.Scan(val); err != nil {
+		t.Fatalf("Scan() failed: %s", err)
+	}
+	if !cidIn.Equal(*cidOut) {
+		t.Fatalf("Round-trip failed: got %s want %s", cidOut, cidIn)
+	}
+}

--- a/data/encoding.go
+++ b/data/encoding.go
@@ -1,0 +1,35 @@
+package data
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+// MarshalJSON implements json.Marshaler.
+func (h Hash) MarshalJSON() ([]byte, error) {
+	return h.cid.MarshalJSON()
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (h *Hash) UnmarshalJSON(data []byte) error {
+	return h.cid.UnmarshalJSON(data)
+}
+
+// Value implements database/sql
+func (h Hash) Value() (driver.Value, error) {
+	return []byte(h.String()), nil
+}
+
+// Scan implements database/sql
+func (h *Hash) Scan(data interface{}) error {
+	v, ok := data.([]byte)
+	if !ok {
+		return fmt.Errorf("Hash did not get bytes: %#v", data)
+	}
+	o, err := ParseHash(string(v))
+	if err != nil {
+		return err
+	}
+	*h = o
+	return nil
+}

--- a/data/encoding_test.go
+++ b/data/encoding_test.go
@@ -1,0 +1,41 @@
+package data
+
+import (
+	"encoding/json"
+	"log"
+	"testing"
+)
+
+func TestHashJSON(t *testing.T) {
+	hashIn := LiteralHash("abc")
+	data, err := json.Marshal(hashIn)
+	if err != nil {
+		t.Fatalf("Marshal() failed: %s", err)
+	}
+	log.Printf("DATA %v", data)
+	hashOut := &Hash{}
+	if err := json.Unmarshal(data, hashOut); err != nil {
+		t.Fatalf("Unmarshal() failed: %s", err)
+	}
+	if !hashIn.Equal(*hashOut) {
+		t.Fatalf("Round-trip failed: got %s want %s", hashOut, hashIn)
+	}
+}
+func TestHashDatabase(t *testing.T) {
+	hashIn := LiteralHash("abc")
+	val, err := hashIn.Value()
+	if err != nil {
+		t.Fatalf("Value() failed: %s", err)
+	}
+	_, ok := val.([]byte)
+	if !ok {
+		t.Fatalf("Value() did not return bytes")
+	}
+	hashOut := &Hash{}
+	if err := hashOut.Scan(val); err != nil {
+		t.Fatalf("Scan() failed: %s", err)
+	}
+	if !hashIn.Equal(*hashOut) {
+		t.Fatalf("Round-trip failed: got %s want %s", hashOut, hashIn)
+	}
+}

--- a/data/hash.go
+++ b/data/hash.go
@@ -50,13 +50,3 @@ func (h Hash) Equal(hh Hash) bool {
 func (h Hash) String() string {
 	return h.cid.String()
 }
-
-// MarshalJSON implements json.Marshaler.
-func (h Hash) MarshalJSON() ([]byte, error) {
-	return h.cid.MarshalJSON()
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (h *Hash) UnmarshalJSON(data []byte) error {
-	return h.cid.UnmarshalJSON(data)
-}

--- a/data/types.go
+++ b/data/types.go
@@ -1,6 +1,14 @@
 package data
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrUnknownType is returned if the type cannot be determined.
+	ErrUnknownType = errors.New("data: unknown type")
+)
 
 // Type is a known type of file such as JPEG or PNG. Only known types of files
 // are copied from source to destination.

--- a/dst/locator.go
+++ b/dst/locator.go
@@ -10,7 +10,8 @@ import (
 )
 
 // Locator is the interface for defining the locations of data in a
-// destination.
+// destination. Locators always return relative URLs, which can be resolved
+// with the destination's base URIs when needed.
 type Locator interface {
 
 	// NewHash generates the hash for data.
@@ -59,14 +60,14 @@ func (l fsLocator) IndexURI() uri.URI {
 	return uri.TrustedNew(l.indexFile)
 }
 
-func (l fsLocator) RefsURI(cid data.Hash) uri.URI {
-	return uri.TrustedNew(l.indexFile)
+func (l fsLocator) RefsURI(hash data.Hash) uri.URI {
+	return l.IndexURI()
 }
 
-// media/2006/2006-01-02/<cid>.<ext>
-// media/Undated/hash(<cid>)/<cid>.<ext>
-// <category>/hash(<cid>)/<cid>.<ext>
-func (l fsLocator) DataURI(cid data.Hash, meta *meta.Meta) uri.URI {
+// media/2006/2006-01-02/<hash>.<ext>
+// media/Undated/hash(<hash>)/<hash>.<ext>
+// <category>/hash(<hash>)/<hash>.<ext>
+func (l fsLocator) DataURI(hash data.Hash, meta *meta.Meta) uri.URI {
 	var (
 		key string
 		ext = meta.Type.Ext()
@@ -82,37 +83,37 @@ func (l fsLocator) DataURI(cid data.Hash, meta *meta.Meta) uri.URI {
 	// Customize the path location for each category.
 	switch category {
 
-	// "media" category names files by cid and organized by date.
+	// "media" category names files by hash and organized by date.
 	case "media":
 		t := meta.DateCreated()
 		if t.IsZero() {
-			key = fmt.Sprintf("%s/%s/%s.%s", category, l.zeroDateDir, l.dirs(cid), ext)
+			key = fmt.Sprintf("%s/%s/%s.%s", category, l.zeroDateDir, l.dirs(hash), ext)
 			return uri.TrustedNew(key)
 		}
 		year := t.Format("2006")
 		date := t.Format("2006-01-02")
-		key = fmt.Sprintf("%s/%s/%s/%s.%s", category, year, date, cid.String(), ext)
+		key = fmt.Sprintf("%s/%s/%s/%s.%s", category, year, date, hash.String(), ext)
 		return uri.TrustedNew(key)
 
-	// Otherwise organize by breaking down the cid.
+	// Otherwise organize by breaking down the hash.
 	default:
 		if ext == "" {
-			key = fmt.Sprintf("%s/%s", category, l.dirs(cid))
+			key = fmt.Sprintf("%s/%s", category, l.dirs(hash))
 		} else {
-			key = fmt.Sprintf("%s/%s.%s", category, l.dirs(cid), ext)
+			key = fmt.Sprintf("%s/%s.%s", category, l.dirs(hash), ext)
 		}
 		return uri.TrustedNew(key)
 	}
 }
 
-// meta/hash(<cid>)/<cid>.json
-func (l fsLocator) MetaURI(cid data.Hash, meta *meta.Meta) uri.URI {
-	key := fmt.Sprintf("meta/%s.%s", l.dirs(cid), "json")
+// meta/hash(<hash>)/<hash>.json
+func (l fsLocator) MetaURI(hash data.Hash, meta *meta.Meta) uri.URI {
+	key := fmt.Sprintf("meta/%s.%s", l.dirs(hash), "json")
 	return uri.TrustedNew(key)
 }
 
-func (l fsLocator) dirs(cid data.Hash) string {
-	s := cid.String()
+func (l fsLocator) dirs(hash data.Hash) string {
+	s := hash.String()
 	if len(s) > 4 {
 		return fmt.Sprintf("%s/%s/%s", s[0:2], s[2:4], s[4:])
 	}

--- a/uri/encoding.go
+++ b/uri/encoding.go
@@ -1,6 +1,10 @@
 package uri
 
-import "encoding/json"
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+)
 
 // MarshalJSON implements json.Marshaler.
 func (u URI) MarshalJSON() ([]byte, error) {
@@ -16,6 +20,25 @@ func (u *URI) UnmarshalJSON(data []byte) error {
 	if s != "" {
 		// Ignore error, we'll get a rawStr uri back and that's fine.
 		newURI, _ := New(s)
+		*u = newURI
+	}
+	return nil
+}
+
+// Value implements database/sql
+func (u URI) Value() (driver.Value, error) {
+	return []byte(u.String()), nil
+}
+
+// Scan implements database/sql
+func (u *URI) Scan(data interface{}) error {
+	v, ok := data.([]byte)
+	if !ok {
+		return fmt.Errorf("URI did not get bytes: %#v", data)
+	}
+	if len(v) != 0 {
+		// Ignore error, we'll get a rawStr uri back and that's fine.
+		newURI, _ := New(string(v))
 		*u = newURI
 	}
 	return nil

--- a/uri/encoding_test.go
+++ b/uri/encoding_test.go
@@ -68,3 +68,22 @@ func TestURIJSON(t *testing.T) {
 		}
 	}
 }
+
+func TestURIDatabase(t *testing.T) {
+	uriIn := TrustedNew("http://example.com/")
+	val, err := uriIn.Value()
+	if err != nil {
+		t.Fatalf("Value() failed: %s", err)
+	}
+	_, ok := val.([]byte)
+	if !ok {
+		t.Fatalf("Value() did not return bytes")
+	}
+	uriOut := &URI{}
+	if err := uriOut.Scan(val); err != nil {
+		t.Fatalf("Scan() failed: %s", err)
+	}
+	if !uriIn.Equal(*uriOut) {
+		t.Fatalf("Round-trip failed: got %s want %s", uriOut, uriIn)
+	}
+}


### PR DESCRIPTION
A few misc improvements:

* [x] Add database/sql encoding for basic types
* [x] Clarify that `dsts.Locator` should return relative URI