### PR TITLE
Src-specific metadata

### DIFF
--- a/meta/encoding.go
+++ b/meta/encoding.go
@@ -5,31 +5,41 @@ import (
 	"time"
 
 	"github.com/recentralized/structure/data"
+	"github.com/recentralized/structure/index"
 )
 
 type metaJSON struct {
-	Version     string    `json:"version"`
-	Type        data.Type `json:"type"`
-	ContentType data.Type `json:"content_type,omitempty"`
-	Size        int64     `json:"size"`
-	Inherent    *Content  `json:"inherent,omitempty"`
-	Sidecar     *Content  `json:"sidecar,omitempty"`
-	SrcSpecific           // Embedded fields.
+	Version     string                      `json:"version"`
+	Type        data.Type                   `json:"type"`
+	ContentType data.Type                   `json:"content_type,omitempty"`
+	Size        int64                       `json:"size"`
+	Src         map[index.SrcID]SrcSpecific `json:"src,omitempty"`
+
+	// V0 Fields
+	Inherent      *Content `json:"inherent,omitempty"`
+	Sidecar       *Content `json:"sidecar,omitempty"`
+	V0SrcSpecific          // Embedded fields.
 }
 
 // MarshalJSON converts Meta to JSON.
 func (m Meta) MarshalJSON() ([]byte, error) {
 	j := metaJSON{
-		Version:     m.Version,
-		Type:        m.Type,
-		Size:        m.Size,
-		SrcSpecific: m.V0Srcs,
+		Version:       m.Version,
+		Type:          m.Type,
+		Size:          m.Size,
+		V0SrcSpecific: m.V0Srcs,
 	}
 	if !m.Inherent.isZero() {
 		j.Inherent = &m.Inherent
 	}
 	if !m.V0Sidecar.isZero() {
 		j.Sidecar = &m.V0Sidecar
+	}
+	if m.Src != nil {
+		j.Src = make(map[index.SrcID]SrcSpecific)
+		for k, v := range m.Src {
+			j.Src[k] = v
+		}
 	}
 	return json.Marshal(j)
 }
@@ -46,13 +56,19 @@ func (m *Meta) UnmarshalJSON(data []byte) error {
 		m.Type = j.ContentType
 	}
 	m.Size = j.Size
+	if j.Src != nil {
+		m.Src = make(map[index.SrcID]SrcSpecific)
+		for k, v := range j.Src {
+			m.Src[k] = v
+		}
+	}
 	if j.Inherent != nil {
 		m.Inherent = *j.Inherent
 	}
 	if j.Sidecar != nil {
 		m.V0Sidecar = *j.Sidecar
 	}
-	m.V0Srcs = j.SrcSpecific
+	m.V0Srcs = j.V0SrcSpecific
 	return nil
 }
 

--- a/meta/encoding.go
+++ b/meta/encoding.go
@@ -23,13 +23,13 @@ func (m Meta) MarshalJSON() ([]byte, error) {
 		Version:     m.Version,
 		Type:        m.Type,
 		Size:        m.Size,
-		SrcSpecific: m.Srcs,
+		SrcSpecific: m.V0Srcs,
 	}
 	if !m.Inherent.isZero() {
 		j.Inherent = &m.Inherent
 	}
-	if !m.Sidecar.isZero() {
-		j.Sidecar = &m.Sidecar
+	if !m.V0Sidecar.isZero() {
+		j.Sidecar = &m.V0Sidecar
 	}
 	return json.Marshal(j)
 }
@@ -50,9 +50,9 @@ func (m *Meta) UnmarshalJSON(data []byte) error {
 		m.Inherent = *j.Inherent
 	}
 	if j.Sidecar != nil {
-		m.Sidecar = *j.Sidecar
+		m.V0Sidecar = *j.Sidecar
 	}
-	m.Srcs = j.SrcSpecific
+	m.V0Srcs = j.SrcSpecific
 	return nil
 }
 

--- a/meta/encoding_test.go
+++ b/meta/encoding_test.go
@@ -58,7 +58,7 @@ func TestMetaJSON(t *testing.T) {
 				Version: "v1",
 				Src: map[index.SrcID]SrcSpecific{
 					index.SrcID("s1"): SrcSpecific{
-						Content: Content{
+						Sidecar: &Content{
 							Created: time.Date(1, 2, 3, 4, 5, 6, 7, time.UTC),
 							Image: Image{
 								Width:  100,
@@ -74,7 +74,7 @@ func TestMetaJSON(t *testing.T) {
 					},
 				},
 			},
-			json: `{"version":"v1","type":"","size":0,"src":{"s1":{"created":"0001-02-03T04:05:06.000000007Z","image":{"width":100,"height":60},"exif":{"CreateData":{"id":"0x9004","val":"2013:07:17 19:59:58"}}}}}`,
+			json: `{"version":"v1","type":"","size":0,"src":{"s1":{"sidecar":{"created":"0001-02-03T04:05:06.000000007Z","image":{"width":100,"height":60},"exif":{"CreateData":{"id":"0x9004","val":"2013:07:17 19:59:58"}}}}}}`,
 		},
 		{
 			desc: "v0 sidecar",

--- a/meta/encoding_test.go
+++ b/meta/encoding_test.go
@@ -41,17 +41,24 @@ func TestMetaJSON(t *testing.T) {
 						},
 					},
 				},
-				Sidecar: Content{
+			},
+			json: `{"version":"v1","type":"jpg","size":100,"inherent":{"created":"0001-02-03T04:05:06.000000007Z","image":{"width":100,"height":60},"exif":{"CreateData":{"id":"0x9004","val":"2013:07:17 19:59:58"}}}}`,
+		},
+		{
+			desc: "v0 sidecar",
+			meta: Meta{
+				Version: "v1",
+				V0Sidecar: Content{
 					Created: time.Date(2, 2, 3, 4, 5, 6, 7, time.UTC),
 				},
 			},
-			json: `{"version":"v1","type":"jpg","size":100,"inherent":{"created":"0001-02-03T04:05:06.000000007Z","image":{"width":100,"height":60},"exif":{"CreateData":{"id":"0x9004","val":"2013:07:17 19:59:58"}}},"sidecar":{"created":"0002-02-03T04:05:06.000000007Z"}}`,
+			json: `{"version":"v1","type":"","size":0,"sidecar":{"created":"0002-02-03T04:05:06.000000007Z"}}`,
 		},
 		{
-			desc: "src-specific fields",
+			desc: "v0 src-specific",
 			meta: Meta{
 				Version: "v1",
-				Srcs:    SrcSpecific{
+				V0Srcs:  SrcSpecific{
 					//Flickr:
 				},
 			},

--- a/meta/encoding_test.go
+++ b/meta/encoding_test.go
@@ -53,7 +53,7 @@ func TestMetaJSON(t *testing.T) {
 			json: `{"version":"v1","type":"","size":0,"inherent":{"created":"0001-02-03T04:05:06.000000007Z","image":{"width":100,"height":60},"exif":{"CreateData":{"id":"0x9004","val":"2013:07:17 19:59:58"}}}}`,
 		},
 		{
-			desc: "src-specific",
+			desc: "src-specific: sidecar",
 			meta: Meta{
 				Version: "v1",
 				Src: map[index.SrcID]SrcSpecific{

--- a/meta/encoding_test.go
+++ b/meta/encoding_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/recentralized/structure/data"
+	"github.com/recentralized/structure/index"
 )
 
 func TestMetaJSON(t *testing.T) {
@@ -28,6 +29,13 @@ func TestMetaJSON(t *testing.T) {
 				Version: "v1",
 				Type:    data.JPG,
 				Size:    100,
+			},
+			json: `{"version":"v1","type":"jpg","size":100}`,
+		},
+		{
+			desc: "inherent",
+			meta: Meta{
+				Version: "v1",
 				Inherent: Content{
 					Created: time.Date(1, 2, 3, 4, 5, 6, 7, time.UTC),
 					Image: Image{
@@ -42,7 +50,31 @@ func TestMetaJSON(t *testing.T) {
 					},
 				},
 			},
-			json: `{"version":"v1","type":"jpg","size":100,"inherent":{"created":"0001-02-03T04:05:06.000000007Z","image":{"width":100,"height":60},"exif":{"CreateData":{"id":"0x9004","val":"2013:07:17 19:59:58"}}}}`,
+			json: `{"version":"v1","type":"","size":0,"inherent":{"created":"0001-02-03T04:05:06.000000007Z","image":{"width":100,"height":60},"exif":{"CreateData":{"id":"0x9004","val":"2013:07:17 19:59:58"}}}}`,
+		},
+		{
+			desc: "src-specific",
+			meta: Meta{
+				Version: "v1",
+				Src: map[index.SrcID]SrcSpecific{
+					index.SrcID("s1"): SrcSpecific{
+						Content: Content{
+							Created: time.Date(1, 2, 3, 4, 5, 6, 7, time.UTC),
+							Image: Image{
+								Width:  100,
+								Height: 60,
+							},
+							Exif: Exif{
+								"CreateData": ExifValue{
+									ID:  "0x9004",
+									Val: "2013:07:17 19:59:58",
+								},
+							},
+						},
+					},
+				},
+			},
+			json: `{"version":"v1","type":"","size":0,"src":{"s1":{"created":"0001-02-03T04:05:06.000000007Z","image":{"width":100,"height":60},"exif":{"CreateData":{"id":"0x9004","val":"2013:07:17 19:59:58"}}}}}`,
 		},
 		{
 			desc: "v0 sidecar",
@@ -58,7 +90,7 @@ func TestMetaJSON(t *testing.T) {
 			desc: "v0 src-specific",
 			meta: Meta{
 				Version: "v1",
-				V0Srcs:  SrcSpecific{
+				V0Srcs:  V0SrcSpecific{
 					//Flickr:
 				},
 			},

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/recentralized/structure/data"
+	"github.com/recentralized/structure/index"
 )
 
 const (
@@ -34,12 +35,17 @@ type Meta struct {
 	// Metadata that came from the content itself.
 	Inherent Content
 
+	// Metadata that came from elsewhere on the source.
+	Src map[index.SrcID]SrcSpecific
+
 	// Metadata that came from nearby, such as an XMP sidecar file or other
 	// source of metadata.
+	// Deprecated: Read from V0 only. Use Src[srcID] instead.
 	V0Sidecar Content
 
 	// Metadata that came from the source of the data.
-	V0Srcs SrcSpecific
+	// Deprecated: Read from V0 only. Use Src[srcID] instead.
+	V0Srcs V0SrcSpecific
 }
 
 // New initializes a new Meta at the current version.
@@ -102,7 +108,13 @@ type Image struct {
 
 // SrcSpecific contains source-specific metadata.
 type SrcSpecific struct {
+	Content
 	//Flickr *flickr.FlickrActivity `json:"flickr,omitempty"`
+}
+
+// V0SrcSpecific contains source-specific metadata.
+type V0SrcSpecific struct {
+	// TODO: port v0 sources
 }
 
 func (m Content) isZero() bool {

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -108,7 +108,7 @@ type Image struct {
 
 // SrcSpecific contains source-specific metadata.
 type SrcSpecific struct {
-	Content
+	Sidecar *Content `json:"sidecar,omitempty"`
 	//Flickr *flickr.FlickrActivity `json:"flickr,omitempty"`
 }
 

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -36,10 +36,10 @@ type Meta struct {
 
 	// Metadata that came from nearby, such as an XMP sidecar file or other
 	// source of metadata.
-	Sidecar Content
+	V0Sidecar Content
 
 	// Metadata that came from the source of the data.
-	Srcs SrcSpecific
+	V0Srcs SrcSpecific
 }
 
 // New initializes a new Meta at the current version.
@@ -70,7 +70,7 @@ func ParseJSON(r io.Reader) (*Meta, error) {
 // time available it returns time.Time's zero value.
 func (m *Meta) DateCreated() time.Time {
 	times := []time.Time{
-		m.Sidecar.Created,
+		m.V0Sidecar.Created,
 		m.Inherent.Created,
 	}
 	for _, t := range times {

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -26,15 +26,15 @@ func TestMetaDateCreated(t *testing.T) {
 		{
 			desc: "sidecar with date",
 			m: &Meta{
-				Sidecar: Content{Created: time.Date(2001, 2, 1, 1, 1, 1, 1, time.UTC)},
+				V0Sidecar: Content{Created: time.Date(2001, 2, 1, 1, 1, 1, 1, time.UTC)},
 			},
 			want: time.Date(2001, 2, 1, 1, 1, 1, 1, time.UTC),
 		},
 		{
 			desc: "prefers sidecar to inherent",
 			m: &Meta{
-				Inherent: Content{Created: time.Date(2001, 1, 1, 1, 1, 1, 1, time.UTC)},
-				Sidecar:  Content{Created: time.Date(2001, 2, 1, 1, 1, 1, 1, time.UTC)},
+				Inherent:  Content{Created: time.Date(2001, 1, 1, 1, 1, 1, 1, time.UTC)},
+				V0Sidecar: Content{Created: time.Date(2001, 2, 1, 1, 1, 1, 1, time.UTC)},
 			},
 			want: time.Date(2001, 2, 1, 1, 1, 1, 1, time.UTC),
 		},


### PR DESCRIPTION
This changes how source-specific metadata is stored, ensuring isolation between overlapping data from multiple sources.

From:

```Golang
type Meta struct {
    Sidecar Content
    SrcSpecific SrcSpecific
}
```

To:

```Golang
type Meta struct {
    Src map[index.SrcID] SrcSpecific
}
type SrcSpecific {
    Sidecar Content
   // other fields
}
```

Previously, Sidecar was pretty ambiguous and could be set from multiple places. 

* [x] support old fields as v0
* [ ] add migration test
