### PR TITLE
Add DstItem.Size

### DIFF
--- a/examples/index/main.go
+++ b/examples/index/main.go
@@ -129,6 +129,7 @@ func buildDstItem(layout dst.Layout, dst index.Dst, hash data.Hash, meta *meta.M
 		DstID:    dst.DstID,
 		DataURI:  dataURI,
 		MetaURI:  metaURI,
+		Size:     1024,
 		StoredAt: time.Date(2018, 11, 13, 0, 0, 0, 0, time.UTC),
 	}
 	return item, nil

--- a/examples/index/output.json
+++ b/examples/index/output.json
@@ -30,6 +30,7 @@
           "dst_id": "0e73b6c5-26dc-58a6-8fa9-edd5be9ad99d",
           "data_uri": "media/2018/2018-11-10/f42a59131aaf2e5c475f8a35126b034549c05bd5.jpg",
           "meta_uri": "meta/f4/2a/59131aaf2e5c475f8a35126b034549c05bd5.json",
+          "size": 1024,
           "stored_at": "2018-11-13T00:00:00Z"
         }
       ]

--- a/index/dst.go
+++ b/index/dst.go
@@ -90,6 +90,9 @@ type DstItem struct {
 	// content.MetaReader.
 	MetaURI uri.URI `json:"meta_uri"`
 
+	// Size is the size of the data in bytes.
+	Size uint64 `json:"size"`
+
 	// StoredAt is the time that the item was stored.
 	StoredAt time.Time `json:"stored_at"`
 }

--- a/index/encoding_test.go
+++ b/index/encoding_test.go
@@ -146,7 +146,7 @@ func TestDstItemJSON(t *testing.T) {
 		{
 			desc: "zero value",
 			item: DstItem{},
-			json: `{"dst_id":"","data_uri":"","meta_uri":"","stored_at":null}`,
+			json: `{"dst_id":"","data_uri":"","meta_uri":"","size":0,"stored_at":null}`,
 		},
 		{
 			desc: "basic fields",
@@ -154,9 +154,10 @@ func TestDstItemJSON(t *testing.T) {
 				DstID:    DstID("abc"),
 				DataURI:  uri.TrustedNew("http://example.com/data/abc.jpg"),
 				MetaURI:  uri.TrustedNew("http://example.com/meta/abc.json"),
+				Size:     100,
 				StoredAt: time.Date(1, 2, 3, 4, 5, 6, 7, time.UTC),
 			},
-			json: `{"dst_id":"abc","data_uri":"http://example.com/data/abc.jpg","meta_uri":"http://example.com/meta/abc.json","stored_at":"0001-02-03T04:05:06.000000007Z"}`,
+			json: `{"dst_id":"abc","data_uri":"http://example.com/data/abc.jpg","meta_uri":"http://example.com/meta/abc.json","size":100,"stored_at":"0001-02-03T04:05:06.000000007Z"}`,
 		},
 	}
 	for _, tt := range tests {
@@ -208,11 +209,12 @@ func TestURefJSON(t *testing.T) {
 						DstID:    DstID("abc"),
 						DataURI:  uri.TrustedNew("http://example.com/data/abc.jpg"),
 						MetaURI:  uri.TrustedNew("http://example.com/meta/abc.json"),
+						Size:     100,
 						StoredAt: time.Date(1, 2, 3, 4, 5, 6, 7, time.UTC),
 					},
 				},
 			},
-			json: `{"hash":"xyz","srcs":[{"src_id":"a","data_uri":"http://example.com/data.jpg","meta_uri":"http://example.com/meta.json","modified_at":"2015-02-03T04:05:06.000000007Z"}],"dsts":[{"dst_id":"abc","data_uri":"http://example.com/data/abc.jpg","meta_uri":"http://example.com/meta/abc.json","stored_at":"0001-02-03T04:05:06.000000007Z"}]}`,
+			json: `{"hash":"xyz","srcs":[{"src_id":"a","data_uri":"http://example.com/data.jpg","meta_uri":"http://example.com/meta.json","modified_at":"2015-02-03T04:05:06.000000007Z"}],"dsts":[{"dst_id":"abc","data_uri":"http://example.com/data/abc.jpg","meta_uri":"http://example.com/meta/abc.json","size":100,"stored_at":"0001-02-03T04:05:06.000000007Z"}]}`,
 		},
 	}
 	for _, tt := range tests {
@@ -276,7 +278,7 @@ func TestIndexJSON(t *testing.T) {
 					},
 				},
 			},
-			json: `{"version":"v1","refs":[{"hash":"xyz","srcs":[{"src_id":"a","data_uri":"","meta_uri":"","modified_at":null}],"dsts":[{"dst_id":"abc","data_uri":"","meta_uri":"","stored_at":null}]}]}`,
+			json: `{"version":"v1","refs":[{"hash":"xyz","srcs":[{"src_id":"a","data_uri":"","meta_uri":"","modified_at":null}],"dsts":[{"dst_id":"abc","data_uri":"","meta_uri":"","size":0,"stored_at":null}]}]}`,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Adds a Size field to DstItem to store the byte size of the item. Closes #10 

Open questions:

* Should it really be on DstItem? Size makes ore sense on Ref if it's the size of the data. If it's the size of the data at rest, it would make sense on DstItem if the data could be compressed for example.