### PR TITLE
add URef.DecomposeRefs

### DIFF
--- a/index/index_test.go
+++ b/index/index_test.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/recentralized/structure/data"
@@ -285,5 +286,71 @@ func TestIndexRef(t *testing.T) {
 		if !ok {
 			t.Errorf("%q GetRef must be ok after adding", tt.desc)
 		}
+	}
+}
+
+func TestURefDecomposeRefs(t *testing.T) {
+	tests := []struct {
+		desc string
+		uref *URef
+		want []Ref
+	}{
+		{
+			desc: "zero value",
+			uref: &URef{},
+			want: []Ref{},
+		},
+		{
+			desc: "srcs only",
+			uref: &URef{
+				Hash: data.LiteralHash("123"),
+				Srcs: []SrcItem{
+					{SrcID: SrcID("s1")},
+				},
+			},
+			want: []Ref{},
+		},
+		{
+			desc: "dsts only",
+			uref: &URef{
+				Hash: data.LiteralHash("123"),
+				Dsts: []DstItem{
+					{DstID: DstID("d1")},
+				},
+			},
+			want: []Ref{},
+		},
+		{
+			desc: "srcs and dsts",
+			uref: &URef{
+				Hash: data.LiteralHash("123"),
+				Srcs: []SrcItem{
+					{SrcID: SrcID("s1")},
+					{SrcID: SrcID("s2")},
+					{SrcID: SrcID("s3")},
+				},
+				Dsts: []DstItem{
+					{DstID: DstID("d1")},
+					{DstID: DstID("d2")},
+				},
+			},
+			want: []Ref{
+				{Hash: data.LiteralHash("123"), Src: SrcItem{SrcID: SrcID("s1")}, Dst: DstItem{DstID: DstID("d1")}},
+				{Hash: data.LiteralHash("123"), Src: SrcItem{SrcID: SrcID("s1")}, Dst: DstItem{DstID: DstID("d2")}},
+				{Hash: data.LiteralHash("123"), Src: SrcItem{SrcID: SrcID("s2")}, Dst: DstItem{DstID: DstID("d1")}},
+				{Hash: data.LiteralHash("123"), Src: SrcItem{SrcID: SrcID("s2")}, Dst: DstItem{DstID: DstID("d2")}},
+				{Hash: data.LiteralHash("123"), Src: SrcItem{SrcID: SrcID("s3")}, Dst: DstItem{DstID: DstID("d1")}},
+				{Hash: data.LiteralHash("123"), Src: SrcItem{SrcID: SrcID("s3")}, Dst: DstItem{DstID: DstID("d2")}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got := tt.uref.DecomposeRefs()
+			if got, want := got, tt.want; !reflect.DeepEqual(got, want) {
+				t.Errorf("URef.DecomposeRefs()\ngot  %#v\nwant %#v", got, want)
+			}
+		})
+
 	}
 }

--- a/index/ref.go
+++ b/index/ref.go
@@ -62,6 +62,21 @@ func (r URef) String() string {
 	return fmt.Sprintf("<URef %s srcs:%d dsts:%d>", r.Hash, len(r.Srcs), len(r.Dsts))
 }
 
+// DecomposeRefs returns an array of individual Refs.
+func (r URef) DecomposeRefs() []Ref {
+	refs := make([]Ref, 0, len(r.Srcs)*len(r.Dsts))
+	for _, s := range r.Srcs {
+		for _, d := range r.Dsts {
+			refs = append(refs, Ref{
+				Hash: r.Hash,
+				Src:  s,
+				Dst:  d,
+			})
+		}
+	}
+	return refs
+}
+
 // AddSrc adds a SrcItem to the ref. If a matching SrcItem exists, it's mutable
 // attributes will be updated. The method returns true if any changes to the
 // URef or existing SrcItem occurred.


### PR DESCRIPTION
Add URef.DecomposeRefs.

This lets you take a `index.URef` and turn it into a set of `index.Ref`. Useful if you are reading from an index, and want to write out individual Refs to another data store.