### PR TITLE
Convenience methods

### DIFF
--- a/data/hash.go
+++ b/data/hash.go
@@ -47,6 +47,12 @@ func (h Hash) Equal(hh Hash) bool {
 	return h.cid.Equal(hh.cid)
 
 }
+
+// IsZero returns true if the Hash is its zero value.
+func (h Hash) IsZero() bool {
+	return h == undefHash
+}
+
 func (h Hash) String() string {
 	return h.cid.String()
 }

--- a/data/hash_test.go
+++ b/data/hash_test.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"bytes"
+	"reflect"
 	"testing"
 
 	"github.com/recentralized/structure/cid"
@@ -31,5 +32,32 @@ func TestHashEqual(t *testing.T) {
 	}
 	if h1.Equal(h3) {
 		t.Errorf("different data must NOT be equal")
+	}
+}
+func TestHashIsZero(t *testing.T) {
+	tests := []struct {
+		desc     string
+		hash     Hash
+		wantZero bool
+	}{
+		{
+			desc:     "unspecified is zero",
+			wantZero: true,
+		},
+		{
+			desc:     "undef is zero",
+			hash:     undefHash,
+			wantZero: true,
+		},
+		{
+			desc:     "value is not zero",
+			hash:     LiteralHash("ok"),
+			wantZero: false,
+		},
+	}
+	for _, tt := range tests {
+		if got, want := tt.hash.IsZero(), tt.wantZero; !reflect.DeepEqual(got, want) {
+			t.Errorf("%q IsZero got %t want %t", tt.desc, got, want)
+		}
 	}
 }

--- a/index/index.go
+++ b/index/index.go
@@ -137,23 +137,3 @@ func (i *Index) GetRef(hash data.Hash) (*URef, bool) {
 	}
 	return nil, false
 }
-
-// GetSrcItem returns a SrcItem for content with hash and stored in srcID. If
-// no SrcItem is found, it returns false.
-func (i *Index) GetSrcItem(hash data.Hash, srcID SrcID) (SrcItem, bool) {
-	ref, ok := i.GetRef(hash)
-	if ok {
-		return ref.GetSrc(srcID)
-	}
-	return SrcItem{}, false
-}
-
-// GetDstItem returns a DstItem for content with hash and stored in dstID. If
-// no DstItem is found, it returns false.
-func (i *Index) GetDstItem(hash data.Hash, dstID DstID) (DstItem, bool) {
-	ref, ok := i.GetRef(hash)
-	if ok {
-		return ref.GetDst(dstID)
-	}
-	return DstItem{}, false
-}

--- a/index/ref.go
+++ b/index/ref.go
@@ -112,25 +112,3 @@ func (r *URef) AddDst(dst DstItem) bool {
 	r.Dsts = append(r.Dsts, dst)
 	return true
 }
-
-// GetSrc returns the source item matching srcID. It return false if no source
-// item was found.
-func (r *URef) GetSrc(srcID SrcID) (SrcItem, bool) {
-	for _, item := range r.Srcs {
-		if item.SrcID == srcID {
-			return item, true
-		}
-	}
-	return SrcItem{}, false
-}
-
-// GetDst returns the destination item matching dstID. It return false if no
-// destination item was found.
-func (r *URef) GetDst(dstID DstID) (DstItem, bool) {
-	for _, item := range r.Dsts {
-		if item.DstID == dstID {
-			return item, true
-		}
-	}
-	return DstItem{}, false
-}

--- a/uri/uri.go
+++ b/uri/uri.go
@@ -84,6 +84,11 @@ func (u URI) uriString() string {
 	return u.String()
 }
 
+// IsZero returns true if this URI is its zero value.
+func (u URI) IsZero() bool {
+	return u == Empty
+}
+
 // Equal compares the string representation of another URI.
 func (u URI) Equal(ref uriStringer) bool {
 	return u.uriString() == ref.uriString()

--- a/uri/uri_test.go
+++ b/uri/uri_test.go
@@ -123,6 +123,45 @@ func TestNewFromURL(t *testing.T) {
 		}
 	}
 }
+func TestIsZero(t *testing.T) {
+	newURL := func(str string) *url.URL {
+		u, err := url.Parse(str)
+		if err != nil {
+			t.Fatalf("failed to parse URL: %s", err)
+		}
+		return u
+	}
+	tests := []struct {
+		desc     string
+		uri      URI
+		wantZero bool
+	}{
+		{
+			desc:     "zero is zero",
+			wantZero: true,
+		},
+		{
+			desc:     "Empty is zero",
+			uri:      Empty,
+			wantZero: true,
+		},
+		{
+			desc:     "any url is non-zero",
+			uri:      URI{url: newURL("ok")},
+			wantZero: false,
+		},
+		{
+			desc:     "any rawStr is non-zero",
+			uri:      URI{rawStr: "ok"},
+			wantZero: false,
+		},
+	}
+	for _, tt := range tests {
+		if got, want := tt.uri.IsZero(), tt.wantZero; got != want {
+			t.Errorf("%q IsZero() got %t want %t", tt.desc, got, want)
+		}
+	}
+}
 func TestString(t *testing.T) {
 	newURL := func(str string) *url.URL {
 		u, err := url.Parse(str)


### PR DESCRIPTION
This clarifies some convenience methods:

* [x] Removed `index.Ref.GetSrc` and `index.Ref.GetDst` both obscure that we may very likely have multiple sources or destinations of a given ID. 
* [x] Added `IsZero` to `uri.URI` and `data.Hash`