### PR TITLE
Change behavior of Empty URI

### DIFF
--- a/uri/fileuri.go
+++ b/uri/fileuri.go
@@ -16,7 +16,7 @@ import (
 func NewFilePath(path string) (FilePath, error) {
 	var err error
 	if path, err = cleanPath(path); err != nil {
-		return FilePath{Empty}, err
+		return FilePath{zero}, err
 	}
 	url := &url.URL{Scheme: "file", Path: path}
 	return FilePath{NewFromURL(url)}, nil
@@ -29,7 +29,7 @@ func NewFilePath(path string) (FilePath, error) {
 func NewDirPath(path string) (FilePath, error) {
 	var err error
 	if path, err = cleanPath(path); err != nil {
-		return FilePath{Empty}, err
+		return FilePath{zero}, err
 	}
 	// NOTE: ASCII-Only. Is that ok?
 	if path[len(path)-1:] != "/" {

--- a/uri/uri.go
+++ b/uri/uri.go
@@ -21,27 +21,47 @@ type URI struct {
 	rawStr string
 }
 
-// Empty is an empty URI. A good default when an empty URI is ok.
-var Empty = URI{}
+// Error is the type of error returned by URI operations.
+type Error struct {
+	Msg string
+	Err error
+}
 
-// New parses str and returns a URI. If the input is an empty string or blank,
-// the package variable url.Empty is returned, which you can do an equality
-// test against. If there is a problem parsing the input, the error is
-// returned, but so is a URI. You may choose whether you wish to proceed.
+func (e Error) Error() string {
+	if e.Err == nil {
+		return fmt.Sprintf("uri: %s", e.Msg)
+	}
+	return fmt.Sprintf("uri: %s (%s)", e.Msg, e.Err)
+}
+
+// ErrEmptyInput is returned if the input is empty. If a URI is returned along
+// with this error, the URI is functional, but probably not what you want.
+var ErrEmptyInput = Error{Msg: "input is empty"}
+
+// ErrBadInput is returned if the input is invalid. If a URI is returned along
+// with this error, the URI is functional but cannot be converted to a url.URL.
+var ErrBadInput = Error{Msg: "input is invalid"}
+
+// New parses str and returns a URI. If the input is an empty or blank string,
+// it returns ErrEmptyInput. If any other problem occurs while parsing str it
+// returns ErrBadInput. You may choose to ignore these errors, see the comments
+// on the error values.
 //
 // uri, err := uri.New("http://www.example.com")
 //
 func New(str string) (URI, error) {
 	str = strings.TrimSpace(str)
 	if str == "" {
-		return Empty, nil
+		return URI{url: &url.URL{}}, ErrEmptyInput
 	}
-	url, err := url.Parse(str)
+	u, err := url.Parse(str)
 	if err != nil {
-		return URI{rawStr: str}, err
+		return URI{rawStr: str}, ErrBadInput
 	}
-	return URI{url: url}, nil
+	return URI{url: u}, nil
 }
+
+var zero = URI{}
 
 // TrustedNew calls New and ignores any error. ONLY use this if you trust the
 // input.
@@ -52,7 +72,7 @@ func TrustedNew(str string) URI {
 
 // NewFromURL converts the URL to a URI. You can use this in tandem with
 // URI.URL() to modify the URL and then create a new URI. Passing a nil URL
-// will result in uri.Empty.
+// will result in the zero value.
 //
 // uri, _ := uri.New("http://www.example.com")
 // url := uri.URL()
@@ -61,7 +81,7 @@ func TrustedNew(str string) URI {
 //
 func NewFromURL(url *url.URL) URI {
 	if url == nil {
-		return Empty
+		return zero
 	}
 	// Ignore error, assuming url.URL is always round-trippable.
 	uri, _ := New(url.String())
@@ -86,7 +106,10 @@ func (u URI) uriString() string {
 
 // IsZero returns true if this URI is its zero value.
 func (u URI) IsZero() bool {
-	return u == Empty
+	if u.url != nil {
+		return u.url.String() == ""
+	}
+	return u.rawStr == ""
 }
 
 // Equal compares the string representation of another URI.
@@ -94,9 +117,8 @@ func (u URI) Equal(ref uriStringer) bool {
 	return u.uriString() == ref.uriString()
 }
 
-// URL returns a url.URL representation. It may be nil if the URI
-// cannot be handled by url.URL. Modifying the returned URL will *not*
-// alter this URI.
+// URL returns a url.URL representation. It may be nil if the URI could not be
+// parsed. Modifying the returned URL will *not* alter this URI.
 func (u URI) URL() *url.URL {
 	if u.url == nil {
 		return nil
@@ -109,16 +131,10 @@ func (u URI) URL() *url.URL {
 // Resolving uri.Empty with uri.Empty results in uri.Empty. Resolving
 // any non-valid URI results in an error.
 func (u URI) ResolveReference(ref URI) (URI, error) {
-	refURL := ref.URL()
-	if u == Empty && ref == Empty {
-		return Empty, nil
+	a := u.URL()
+	b := ref.URL()
+	if a == nil || b == nil {
+		return zero, ErrBadInput
 	}
-	if u.url != nil && refURL != nil {
-		url := u.url.ResolveReference(refURL)
-		if url.String() == "" {
-			return Empty, nil
-		}
-		return URI{url: url}, nil
-	}
-	return Empty, fmt.Errorf("cannot resolve %q and %q", u, ref)
+	return URI{url: a.ResolveReference(b)}, nil
 }

--- a/uri/uri_test.go
+++ b/uri/uri_test.go
@@ -2,10 +2,12 @@ package uri
 
 import (
 	"net/url"
+	"reflect"
 	"testing"
 )
 
 func TestNew(t *testing.T) {
+	_, parseErr := url.Parse("%")
 	tests := []struct {
 		str        string
 		wantStr    string
@@ -18,14 +20,14 @@ func TestNew(t *testing.T) {
 			str:      "",
 			wantStr:  "",
 			wantZero: true,
-			wantErr:  ErrEmptyInput,
+			wantErr:  errEmpty,
 		},
 		{
 			// Blank string is an error.
 			str:      "  ",
 			wantStr:  "",
 			wantZero: true,
-			wantErr:  ErrEmptyInput,
+			wantErr:  errEmpty,
 		},
 		{
 			// Path only.
@@ -56,7 +58,7 @@ func TestNew(t *testing.T) {
 			// Parse error.
 			str:        "%",
 			wantStr:    "%",
-			wantErr:    ErrBadInput,
+			wantErr:    Error{Err: parseErr, invalid: true},
 			wantNilURL: true,
 		},
 		{
@@ -77,8 +79,8 @@ func TestNew(t *testing.T) {
 	}
 	for _, tt := range tests {
 		got, err := New(tt.str)
-		if err != tt.wantErr {
-			t.Errorf("%q New() want %s, got %s", tt.str, err, tt.wantErr)
+		if !reflect.DeepEqual(err, tt.wantErr) {
+			t.Errorf("%q New() want %q, got %q", tt.str, err, tt.wantErr)
 		}
 		if gotStr := got.String(); gotStr != tt.wantStr {
 			t.Errorf("%q New() String() got %#v, want %#v", tt.str, gotStr, tt.wantStr)
@@ -386,25 +388,25 @@ func TestResolveReference(t *testing.T) {
 			desc:    "append valid url to invalid url",
 			base:    URI{rawStr: "/something"},
 			ref:     URI{url: newURL("/path")},
-			wantErr: ErrBadInput,
+			wantErr: errInvalid,
 		},
 		{
 			desc:    "append invalid url to valid url",
 			base:    URI{url: newURL("/path")},
 			ref:     URI{rawStr: "/something"},
-			wantErr: ErrBadInput,
+			wantErr: errInvalid,
 		},
 		{
 			desc:    "append invalid url to invalid url",
 			base:    URI{rawStr: "/a"},
 			ref:     URI{rawStr: "/b"},
-			wantErr: ErrBadInput,
+			wantErr: errInvalid,
 		},
 		{
 			desc:    "append empty to empty",
 			base:    zero,
 			ref:     zero,
-			wantErr: ErrBadInput,
+			wantErr: errInvalid,
 		},
 	}
 	for _, tt := range tests {

--- a/uri/uri_test.go
+++ b/uri/uri_test.go
@@ -6,28 +6,26 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	empty1, _ := New("")
-	empty2, _ := New("   ")
-	if empty1 != Empty {
-		t.Errorf("empty URI must equal the constant")
-	}
-	if empty2 != Empty {
-		t.Errorf("blank URI must equal the constant")
-	}
 	tests := []struct {
-		str     string
-		wantStr string
-		wantErr bool
+		str        string
+		wantStr    string
+		wantErr    error
+		wantZero   bool
+		wantNilURL bool
 	}{
 		{
-			// Empty string is ok.
-			str:     "",
-			wantStr: "",
+			// Empty string is an error.
+			str:      "",
+			wantStr:  "",
+			wantZero: true,
+			wantErr:  ErrEmptyInput,
 		},
 		{
-			// Blank string is ok.
-			str:     "  ",
-			wantStr: "",
+			// Blank string is an error.
+			str:      "  ",
+			wantStr:  "",
+			wantZero: true,
+			wantErr:  ErrEmptyInput,
 		},
 		{
 			// Path only.
@@ -56,9 +54,10 @@ func TestNew(t *testing.T) {
 		},
 		{
 			// Parse error.
-			str:     "%",
-			wantStr: "%",
-			wantErr: true,
+			str:        "%",
+			wantStr:    "%",
+			wantErr:    ErrBadInput,
+			wantNilURL: true,
 		},
 		{
 			// AWS
@@ -78,17 +77,29 @@ func TestNew(t *testing.T) {
 	}
 	for _, tt := range tests {
 		got, err := New(tt.str)
-		if tt.wantErr {
-			if err == nil {
-				t.Errorf("%q New() want error, got none", tt.str)
-			}
-		} else {
-			if err != nil {
-				t.Errorf("%q New() got Err, want none: %s", tt.str, err)
-			}
+		if err != tt.wantErr {
+			t.Errorf("%q New() want %s, got %s", tt.str, err, tt.wantErr)
 		}
 		if gotStr := got.String(); gotStr != tt.wantStr {
 			t.Errorf("%q New() String() got %#v, want %#v", tt.str, gotStr, tt.wantStr)
+		}
+		if tt.wantZero {
+			if !got.IsZero() {
+				t.Errorf("%q IsZero() got %t, want %t", tt.str, got.IsZero(), tt.wantZero)
+			}
+		} else {
+			if got.IsZero() {
+				t.Errorf("%q IsZero() got %t, want %t", tt.str, got.IsZero(), tt.wantZero)
+			}
+		}
+		if tt.wantNilURL {
+			if got.URL() != nil {
+				t.Errorf("%q URL() must be nil", tt.str)
+			}
+		} else {
+			if got.URL() == nil {
+				t.Errorf("%q URL() must not be nil", tt.str)
+			}
 		}
 	}
 }
@@ -113,7 +124,7 @@ func TestNewFromURL(t *testing.T) {
 		{
 			desc: "nil url",
 			url:  nil,
-			uri:  Empty,
+			uri:  zero,
 		},
 	}
 	for _, tt := range tests {
@@ -141,12 +152,17 @@ func TestIsZero(t *testing.T) {
 			wantZero: true,
 		},
 		{
-			desc:     "Empty is zero",
-			uri:      Empty,
+			desc:     "zero var is zero",
+			uri:      zero,
 			wantZero: true,
 		},
 		{
-			desc:     "any url is non-zero",
+			desc:     "empty url is zero",
+			uri:      URI{url: newURL("")},
+			wantZero: true,
+		},
+		{
+			desc:     "non-empty url is non-zero",
 			uri:      URI{url: newURL("ok")},
 			wantZero: false,
 		},
@@ -323,17 +339,12 @@ func TestResolveReference(t *testing.T) {
 		}
 		return u
 	}
-	e := URI{url: newURL("")}
-	re, _ := e.ResolveReference(e)
-	if re != Empty {
-		t.Errorf("Resolving to Empty must == Empty")
-	}
 	tests := []struct {
 		desc    string
 		base    URI
 		ref     URI
 		want    URI
-		wantErr bool
+		wantErr error
 	}{
 		{
 			desc: "append url path",
@@ -375,42 +386,34 @@ func TestResolveReference(t *testing.T) {
 			desc:    "append valid url to invalid url",
 			base:    URI{rawStr: "/something"},
 			ref:     URI{url: newURL("/path")},
-			wantErr: true,
+			wantErr: ErrBadInput,
 		},
 		{
 			desc:    "append invalid url to valid url",
 			base:    URI{url: newURL("/path")},
 			ref:     URI{rawStr: "/something"},
-			wantErr: true,
+			wantErr: ErrBadInput,
 		},
 		{
 			desc:    "append invalid url to invalid url",
 			base:    URI{rawStr: "/a"},
 			ref:     URI{rawStr: "/b"},
-			wantErr: true,
+			wantErr: ErrBadInput,
 		},
 		{
-			desc: "append empty to empty",
-			base: Empty,
-			ref:  Empty,
-			want: Empty,
+			desc:    "append empty to empty",
+			base:    zero,
+			ref:     zero,
+			wantErr: ErrBadInput,
 		},
 	}
 	for _, tt := range tests {
 		got, err := tt.base.ResolveReference(tt.ref)
-		if tt.wantErr {
-			if err == nil {
-				t.Errorf("%q wants error, got none", tt.desc)
-			}
-		} else {
-			if err != nil {
-				t.Errorf("%q wants error no error, got: %s", tt.desc, err)
-			}
+		if err != tt.wantErr {
+			t.Errorf("%q ResolveReference got err %q want %q", tt.desc, err, tt.wantErr)
 		}
-		if err == nil {
-			if !got.Equal(tt.want) {
-				t.Errorf("%q ResolveReference() got %#v, want %#v", tt.desc, got, tt.want)
-			}
+		if !got.Equal(tt.want) {
+			t.Errorf("%q ResolveReference() got %#v, want %#v", tt.desc, got, tt.want)
 		}
 	}
 }


### PR DESCRIPTION
I don't like to change the behavior of the `uri` package, but this corrects a bit of poor judgement early on. 

Currently, calling `uri.New` with an empty string returns the value `uri.Empty` which is effectively the zero value. The problem is that if user then calls `URI.URL()` they get nil, and probably a panic downstream. 

Since in practice an empty string URI probably isn't what you want, this changes `uri.New` to return an error. In accordance with the goal of this package to represent all possible URIs, even those that can't be represented by `url.URL`, we still return a URI. We also return a new type `uri.Error` which the user can inspect to find out why the error occurred. In the unlikely case that they're ok with empty or other invalid URI, they can proceed.

I also removed the package var `uri.Empty` in favor of the recently added `URI.IsZero()`. `IsZero()` is slightly modified to return true if if the URI's string representation is the empty string. This aligns better with the behavior of `uri.New`.

TL;DR - URI is less forgiving up front and empty uris are more apparent.