### PR TITLE
Fix hash encoding

### DIFF
--- a/data/encoding.go
+++ b/data/encoding.go
@@ -26,10 +26,12 @@ func (h *Hash) Scan(data interface{}) error {
 	if !ok {
 		return fmt.Errorf("Hash did not get bytes: %#v", data)
 	}
-	o, err := ParseHash(string(v))
-	if err != nil {
-		return err
+	if len(v) > 0 {
+		o, err := ParseHash(string(v))
+		if err != nil {
+			return err
+		}
+		*h = o
 	}
-	*h = o
 	return nil
 }

--- a/data/encoding_test.go
+++ b/data/encoding_test.go
@@ -2,7 +2,6 @@ package data
 
 import (
 	"encoding/json"
-	"log"
 	"reflect"
 	"testing"
 )
@@ -13,13 +12,32 @@ func TestHashJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Marshal() failed: %s", err)
 	}
-	log.Printf("DATA %v", data)
 	hashOut := &Hash{}
 	if err := json.Unmarshal(data, hashOut); err != nil {
 		t.Fatalf("Unmarshal() failed: %s", err)
 	}
 	if !hashIn.Equal(*hashOut) {
 		t.Fatalf("Round-trip failed: got %s want %s", hashOut, hashIn)
+	}
+	if !reflect.DeepEqual(hashIn, *hashOut) {
+		t.Fatalf("Round-trip DeepEqual failed: got %#v want %#v", hashOut, hashIn)
+	}
+}
+func TestHashJSONEmpty(t *testing.T) {
+	var hashIn Hash
+	data, err := json.Marshal(hashIn)
+	if err != nil {
+		t.Fatalf("Marshal() failed: %s", err)
+	}
+	hashOut := &Hash{}
+	if err := json.Unmarshal(data, hashOut); err != nil {
+		t.Fatalf("Unmarshal() failed: %s", err)
+	}
+	if !hashIn.Equal(*hashOut) {
+		t.Fatalf("Round-trip failed: got %s want %s", hashOut, hashIn)
+	}
+	if !reflect.DeepEqual(hashIn, *hashOut) {
+		t.Fatalf("Round-trip DeepEqual failed: got %#v want %#v", hashOut, hashIn)
 	}
 }
 func TestHashDatabase(t *testing.T) {

--- a/data/encoding_test.go
+++ b/data/encoding_test.go
@@ -3,6 +3,7 @@ package data
 import (
 	"encoding/json"
 	"log"
+	"reflect"
 	"testing"
 )
 
@@ -36,6 +37,30 @@ func TestHashDatabase(t *testing.T) {
 		t.Fatalf("Scan() failed: %s", err)
 	}
 	if !hashIn.Equal(*hashOut) {
-		t.Fatalf("Round-trip failed: got %s want %s", hashOut, hashIn)
+		t.Fatalf("Round-trip Equal failed: got %s want %s", hashOut, hashIn)
+	}
+	if !reflect.DeepEqual(hashIn, *hashOut) {
+		t.Fatalf("Round-trip DeepEqual failed: got %#v want %#v", hashOut, hashIn)
+	}
+}
+func TestHashDatabaseEmpty(t *testing.T) {
+	var hashIn Hash
+	val, err := hashIn.Value()
+	if err != nil {
+		t.Fatalf("Value() failed: %s", err)
+	}
+	_, ok := val.([]byte)
+	if !ok {
+		t.Fatalf("Value() did not return bytes")
+	}
+	hashOut := &Hash{}
+	if err := hashOut.Scan(val); err != nil {
+		t.Fatalf("Scan() failed: %s", err)
+	}
+	if !hashIn.Equal(*hashOut) {
+		t.Fatalf("Round-trip Equal failed: got %s want %s", hashOut, hashIn)
+	}
+	if !reflect.DeepEqual(hashIn, *hashOut) {
+		t.Fatalf("Round-trip DeepEqual failed: got %#v want %#v", hashOut, hashIn)
 	}
 }


### PR DESCRIPTION
This fixes the roundtrip encoding of `data.Hash` in a database. Previously, nil would round-trip as empty string.