### PR TITLE
A DataURI should only use inherent data

### DIFF
--- a/dst/layout.go
+++ b/dst/layout.go
@@ -96,7 +96,7 @@ func (l fsLayout) DataURI(hash data.Hash, meta *meta.Meta) uri.URI {
 
 	// "media" category names files by hash and organized by date.
 	case "media":
-		t := meta.DateCreated()
+		t := meta.Inherent.Created
 		if t.IsZero() {
 			key = fmt.Sprintf("%s/%s/%s.%s", category, l.zeroDateDir, l.dirs(hash), ext)
 			return uri.TrustedNew(key)

--- a/dst/layout_test.go
+++ b/dst/layout_test.go
@@ -25,6 +25,9 @@ func TestFilesystemLayout(t *testing.T) {
 				Inherent: meta.Content{
 					Created: time.Date(2015, 1, 2, 9, 9, 9, 9, time.UTC),
 				},
+				Sidecar: meta.Content{
+					Created: time.Date(2011, 1, 2, 9, 9, 9, 9, time.UTC),
+				},
 			},
 			wantDataURI: "media/2015/2015-01-02/abcdefg.jpg",
 			wantMetaURI: "meta/ab/cd/efg.json",


### PR DESCRIPTION
This is an important fix to the filesystem layout. The date used to determine the path should only look at "inherent" data - that is, data that was in the file itself. Prior to this change, it could also look at "sidecar" data - meaning data that's specific to a source. 

It's incorrect to use sidecar data because the storage location is then dependent on which source the data came from. 