### PR TITLE
Add DstItem.DataType

### DIFF
--- a/data/encoding_test.go
+++ b/data/encoding_test.go
@@ -82,3 +82,47 @@ func TestHashDatabaseEmpty(t *testing.T) {
 		t.Fatalf("Round-trip DeepEqual failed: got %#v want %#v", hashOut, hashIn)
 	}
 }
+func TestStoredJSON(t *testing.T) {
+	storedIn := Stored{Type: JPG, Encoding: GZip}
+	data, err := json.Marshal(storedIn)
+	if err != nil {
+		t.Fatalf("Marshal() failed: %s", err)
+	}
+	if string(data) != `"jpg.gz"` {
+		t.Fatalf("want stringified representation got: %s", data)
+	}
+	storedOut := &Stored{}
+	if err := json.Unmarshal(data, storedOut); err != nil {
+		t.Fatalf("Unmarshal() failed: %s", err)
+	}
+	if storedIn != *storedOut {
+		t.Fatalf("Round-trip failed: got %s want %s", storedOut, storedIn)
+	}
+	if !reflect.DeepEqual(storedIn, *storedOut) {
+		t.Fatalf("Round-trip DeepEqual failed: got %#v want %#v", storedOut, storedIn)
+	}
+}
+func TestStoredDatabase(t *testing.T) {
+	storedIn := Stored{Type: JPG, Encoding: GZip}
+	val, err := storedIn.Value()
+	if err != nil {
+		t.Fatalf("Value() failed: %s", err)
+	}
+	b, ok := val.([]byte)
+	if !ok {
+		t.Fatalf("Value() did not return bytes")
+	}
+	if string(b) != `"jpg.gz"` {
+		t.Fatalf("want stringified representation got: %s", b)
+	}
+	storedOut := &Stored{}
+	if err := storedOut.Scan(val); err != nil {
+		t.Fatalf("Scan() failed: %s", err)
+	}
+	if storedIn != *storedOut {
+		t.Fatalf("Round-trip Equal failed: got %s want %s", storedOut, storedIn)
+	}
+	if !reflect.DeepEqual(storedIn, *storedOut) {
+		t.Fatalf("Round-trip DeepEqual failed: got %#v want %#v", storedOut, storedIn)
+	}
+}

--- a/data/encoding_test.go
+++ b/data/encoding_test.go
@@ -112,7 +112,7 @@ func TestStoredDatabase(t *testing.T) {
 	if !ok {
 		t.Fatalf("Value() did not return bytes")
 	}
-	if string(b) != `"jpg.gz"` {
+	if string(b) != `jpg.gz` {
 		t.Fatalf("want stringified representation got: %s", b)
 	}
 	storedOut := &Stored{}

--- a/data/types.go
+++ b/data/types.go
@@ -138,11 +138,11 @@ func (s Stored) String() string {
 // Ext returns the stored data's standard file extension.
 func (s Stored) Ext() string {
 	switch {
-	case s.Type == UnknownType && s.Encoding == Native:
+	case s.Type == "" && s.Encoding == "":
 		return ""
-	case s.Type == UnknownType:
+	case s.Type == "":
 		return s.Encoding.Ext()
-	case s.Encoding == Native:
+	case s.Encoding == "":
 		return s.Type.Ext()
 	default:
 		return fmt.Sprintf("%s%s", s.Type.Ext(), s.Encoding.Ext())

--- a/data/types.go
+++ b/data/types.go
@@ -10,33 +10,6 @@ var (
 	ErrUnknownType = errors.New("data: unknown type")
 )
 
-// Type is a known type of file such as JPEG or PNG. Only known types of files
-// are copied from source to destination.
-type Type string
-
-func (t Type) String() string {
-	return string(t)
-}
-
-// Ext returns the type's file extension.
-func (t Type) Ext() string {
-	enc := t.Enc()
-	if enc == Native {
-		return string(t)
-	}
-	return fmt.Sprintf("%s.%s", t, enc)
-}
-
-// Enc returns the type's encoding.
-func (t Type) Enc() Encoding {
-	return encodingType[t]
-}
-
-// Class returns the type's class - image, catalog, etc.
-func (t Type) Class() Class {
-	return typeClass[t]
-}
-
 // Type definitions.
 const (
 	// UnknownType is the zero value for Type, meaning it is unknown.
@@ -48,30 +21,12 @@ const (
 	GIF = "gif" // Standard GIF file.
 )
 
-// Encoding is the encoding done to the content for storage. Most types are
-// stored in their native encoding, but for other types we may want to optimize
-// storage by compressing or flattening multi-file structures.
-type Encoding string
-
-func (e Encoding) String() string {
-	return string(e)
-}
-
 // Encoding definitions.
 const (
 	Native Encoding = ""
 	Tar             = "tar"
+	GZip            = "gz"
 )
-
-var encodingType = map[Type]Encoding{}
-
-// Class is the category of content types that a specific type belongs to.
-// JPG, PNG, GIF are all image, etc.
-type Class string
-
-func (c Class) String() string {
-	return string(c)
-}
 
 // Class definitions.
 const (
@@ -79,10 +34,68 @@ const (
 	Image               = "image"
 )
 
-var typeClass = map[Type]Class{
+// Type is a known kind of file such as JPEG or PNG.
+type Type string
+
+func (t Type) String() string {
+	return string(t)
+}
+
+// Ext returns the type's standard file extension.
+func (t Type) Ext() string {
+	return string(t)
+}
+
+// Class returns the type's class: image, catalog, etc.
+func (t Type) Class() Class {
+	return classOfType[t]
+}
+
+// Stored is how a type is formatted for storage.
+type Stored struct {
+	Type     Type
+	Encoding Encoding
+}
+
+func (s Stored) String() string {
+	return s.Ext()
+}
+
+// Ext returns the stored data's standard file extension.
+func (s Stored) Ext() string {
+	if s.Encoding == Native {
+		return fmt.Sprintf("%s", s.Type.Ext())
+	}
+	return fmt.Sprintf("%s.%s", s.Type.Ext(), s.Encoding.Ext())
+}
+
+// Encoding is the encoding of the data for storage. Most types are stored in
+// their native encoding, but we may want to optimize storage by compressing or
+// flattening multi-file structures.
+type Encoding string
+
+func (e Encoding) String() string {
+	return string(e)
+}
+
+// Ext returns the encoding's standard file extension.
+func (e Encoding) Ext() string {
+	return string(e)
+}
+
+// Class is the category of data that a type belongs to. JPG, PNG, GIF are all
+// image, etc.
+type Class string
+
+func (c Class) String() string {
+	return string(c)
+}
+
+var classOfType = map[Type]Class{
 	UnknownType: Uncategorized,
 
 	// Image formats.
 	JPG: Image,
 	PNG: Image,
+	GIF: Image,
 }

--- a/data/types.go
+++ b/data/types.go
@@ -73,9 +73,11 @@ func ParseExt(str string) (Stored, error) {
 		return Stored{}, fmt.Errorf("data: too many parts in extension %q", str)
 	}
 	if len(parts) == 1 {
-		if e := Encoding(parts[0]); e.Ok() {
-			return Stored{Encoding: e}, nil
+		if t := Type(parts[0]); t.Ok() {
+			return Stored{Type: t}, nil
 		}
+		e := Encoding(parts[0])
+		return Stored{Encoding: e}, fmt.Errorf("data: unknown type: %q", str)
 	}
 	t := Type(parts[0])
 	e := Native

--- a/data/types.go
+++ b/data/types.go
@@ -3,6 +3,7 @@ package data
 import (
 	"errors"
 	"fmt"
+	"strings"
 )
 
 var (
@@ -51,6 +52,20 @@ func (t Type) Class() Class {
 	return classOfType[t]
 }
 
+// ParseExt parses an extension, returning the Stored format.
+func ParseExt(str string) (Stored, error) {
+	parts := strings.Split(str, ".")
+	if len(parts) > 2 {
+		return Stored{}, fmt.Errorf("data: too many parts in extension %q", str)
+	}
+	t := Type(parts[0])
+	e := Native
+	if len(parts) == 2 {
+		e = Encoding(parts[1])
+	}
+	return Stored{t, e}, nil
+}
+
 // Stored is how a type is formatted for storage.
 type Stored struct {
 	Type     Type
@@ -75,6 +90,9 @@ func (s Stored) Ext() string {
 type Encoding string
 
 func (e Encoding) String() string {
+	if e == "" {
+		return "<native>"
+	}
 	return string(e)
 }
 

--- a/data/types.go
+++ b/data/types.go
@@ -24,21 +24,26 @@ const (
 
 // Encoding definitions.
 const (
+	// Native is the zero value for Encoding, meaning no encoding.
 	Native Encoding = ""
-	Tar             = "tar"
-	GZip            = "gz"
+
+	Tar  = "tar"
+	GZip = "gz"
 )
 
 // Class definitions.
 const (
-	Uncategorized Class = ""
-	Image               = "image"
+	Unclassified Class = ""
+	Image              = "image"
 )
 
 // Type is a known kind of file such as JPEG or PNG.
 type Type string
 
 func (t Type) String() string {
+	if t == "" {
+		return "data:unknown"
+	}
 	return string(t)
 }
 
@@ -52,18 +57,39 @@ func (t Type) Class() Class {
 	return classOfType[t]
 }
 
+// Ok return true if the type is defined.
+func (t Type) Ok() bool {
+	_, ok := types[t]
+	return ok
+}
+
 // ParseExt parses an extension, returning the Stored format.
 func ParseExt(str string) (Stored, error) {
+	if str == "" {
+		return Stored{}, nil
+	}
 	parts := strings.Split(str, ".")
 	if len(parts) > 2 {
 		return Stored{}, fmt.Errorf("data: too many parts in extension %q", str)
+	}
+	if len(parts) == 1 {
+		if e := Encoding(parts[0]); e.Ok() {
+			return Stored{Encoding: e}, nil
+		}
 	}
 	t := Type(parts[0])
 	e := Native
 	if len(parts) == 2 {
 		e = Encoding(parts[1])
 	}
-	return Stored{t, e}, nil
+	s := Stored{t, e}
+	if !t.Ok() {
+		return s, fmt.Errorf("data: unknown type: %q", t)
+	}
+	if !e.Ok() {
+		return s, fmt.Errorf("data: unknown encoding: %q", e)
+	}
+	return s, nil
 }
 
 // Stored is how a type is formatted for storage.
@@ -73,15 +99,45 @@ type Stored struct {
 }
 
 func (s Stored) String() string {
-	return s.Ext()
+	e := s.Ext()
+	if e == "" {
+		return "data:unknown"
+	}
+	return e
 }
 
 // Ext returns the stored data's standard file extension.
 func (s Stored) Ext() string {
-	if s.Encoding == Native {
+	switch {
+	case s.Type == UnknownType && s.Encoding == Native:
+		return ""
+	case s.Type == UnknownType:
+		return fmt.Sprintf("%s", s.Encoding.Ext())
+	case s.Encoding == Native:
 		return fmt.Sprintf("%s", s.Type.Ext())
+	default:
+		return fmt.Sprintf("%s.%s", s.Type.Ext(), s.Encoding.Ext())
 	}
-	return fmt.Sprintf("%s.%s", s.Type.Ext(), s.Encoding.Ext())
+}
+
+// Ok return true if the storage format is defined.
+func (s Stored) Ok() bool {
+	return s.Type.Ok() && s.Encoding.Ok()
+}
+
+// Format implements fmt.Formatter.
+func (s Stored) Format(f fmt.State, c rune) {
+	switch c {
+	case 's':
+		f.Write([]byte(s.String()))
+	case 'v':
+		f.Write([]byte("Stored["))
+		f.Write([]byte("type: "))
+		f.Write([]byte(s.Type.String()))
+		f.Write([]byte(", encoding: "))
+		f.Write([]byte(s.Encoding.String()))
+		f.Write([]byte("]"))
+	}
 }
 
 // Encoding is the encoding of the data for storage. Most types are stored in
@@ -91,7 +147,7 @@ type Encoding string
 
 func (e Encoding) String() string {
 	if e == "" {
-		return "<native>"
+		return "data:native"
 	}
 	return string(e)
 }
@@ -99,6 +155,12 @@ func (e Encoding) String() string {
 // Ext returns the encoding's standard file extension.
 func (e Encoding) Ext() string {
 	return string(e)
+}
+
+// Ok return true if the encoding is defined.
+func (e Encoding) Ok() bool {
+	_, ok := encodings[e]
+	return ok
 }
 
 // Class is the category of data that a type belongs to. JPG, PNG, GIF are all
@@ -109,8 +171,20 @@ func (c Class) String() string {
 	return string(c)
 }
 
+var types = map[Type]bool{
+	JPG: true,
+	PNG: true,
+	GIF: true,
+}
+
+var encodings = map[Encoding]bool{
+	Native: true,
+	Tar:    true,
+	GZip:   true,
+}
+
 var classOfType = map[Type]Class{
-	UnknownType: Uncategorized,
+	UnknownType: Unclassified,
 
 	// Image formats.
 	JPG: Image,

--- a/data/types.go
+++ b/data/types.go
@@ -120,6 +120,13 @@ type Stored struct {
 	Encoding Encoding
 }
 
+var zeroStored = Stored{}
+
+// IsZero returns true if it's the zero value.
+func (s Stored) IsZero() bool {
+	return s == zeroStored
+}
+
 func (s Stored) String() string {
 	e := strings.TrimPrefix(s.Ext(), ".")
 	if e == "" {

--- a/data/types.go
+++ b/data/types.go
@@ -49,7 +49,10 @@ func (t Type) String() string {
 
 // Ext returns the type's standard file extension.
 func (t Type) Ext() string {
-	return string(t)
+	if t == "" {
+		return ""
+	}
+	return fmt.Sprintf(".%s", t)
 }
 
 // Class returns the type's class: image, catalog, etc.
@@ -65,6 +68,7 @@ func (t Type) Ok() bool {
 
 // ParseExt parses an extension, returning the Stored format.
 func ParseExt(str string) (Stored, error) {
+	str = strings.TrimPrefix(str, ".")
 	if str == "" {
 		return Stored{}, nil
 	}
@@ -101,7 +105,7 @@ type Stored struct {
 }
 
 func (s Stored) String() string {
-	e := s.Ext()
+	e := strings.TrimPrefix(s.Ext(), ".")
 	if e == "" {
 		return "data:unknown"
 	}
@@ -114,11 +118,11 @@ func (s Stored) Ext() string {
 	case s.Type == UnknownType && s.Encoding == Native:
 		return ""
 	case s.Type == UnknownType:
-		return fmt.Sprintf("%s", s.Encoding.Ext())
+		return s.Encoding.Ext()
 	case s.Encoding == Native:
-		return fmt.Sprintf("%s", s.Type.Ext())
+		return s.Type.Ext()
 	default:
-		return fmt.Sprintf("%s.%s", s.Type.Ext(), s.Encoding.Ext())
+		return fmt.Sprintf("%s%s", s.Type.Ext(), s.Encoding.Ext())
 	}
 }
 
@@ -156,7 +160,10 @@ func (e Encoding) String() string {
 
 // Ext returns the encoding's standard file extension.
 func (e Encoding) Ext() string {
-	return string(e)
+	if e == "" {
+		return ""
+	}
+	return fmt.Sprintf(".%s", e)
 }
 
 // Ok return true if the encoding is defined.

--- a/data/types_test.go
+++ b/data/types_test.go
@@ -195,10 +195,14 @@ func TestParseExt(t *testing.T) {
 		wantErr error
 	}{
 		{
-
 			desc: "just type",
 			ext:  "jpg",
-			want: Stored{JPG, Native},
+			want: Stored{Type: JPG},
+		},
+		{
+			desc: "just encoding",
+			ext:  "gz",
+			want: Stored{Encoding: GZip},
 		},
 		{
 			desc: "type and encoding",

--- a/data/types_test.go
+++ b/data/types_test.go
@@ -28,7 +28,7 @@ func TestType(t *testing.T) {
 			typ:       "foo",
 			wantOk:    false,
 			wantStr:   "foo",
-			wantExt:   "foo",
+			wantExt:   ".foo",
 			wantClass: Unclassified,
 		},
 		{
@@ -36,7 +36,7 @@ func TestType(t *testing.T) {
 			typ:       JPG,
 			wantOk:    true,
 			wantStr:   "jpg",
-			wantExt:   "jpg",
+			wantExt:   ".jpg",
 			wantClass: Image,
 		},
 		{
@@ -44,7 +44,7 @@ func TestType(t *testing.T) {
 			typ:       PNG,
 			wantOk:    true,
 			wantStr:   "png",
-			wantExt:   "png",
+			wantExt:   ".png",
 			wantClass: Image,
 		},
 		{
@@ -52,7 +52,7 @@ func TestType(t *testing.T) {
 			typ:       GIF,
 			wantOk:    true,
 			wantStr:   "gif",
-			wantExt:   "gif",
+			wantExt:   ".gif",
 			wantClass: Image,
 		},
 	}
@@ -94,21 +94,21 @@ func TestEncoding(t *testing.T) {
 			enc:     "foo",
 			wantOk:  false,
 			wantStr: "foo",
-			wantExt: "foo",
+			wantExt: ".foo",
 		},
 		{
 			desc:    "tar",
 			enc:     Tar,
 			wantOk:  true,
 			wantStr: "tar",
-			wantExt: "tar",
+			wantExt: ".tar",
 		},
 		{
 			desc:    "gzip",
 			enc:     GZip,
 			wantOk:  true,
 			wantStr: "gz",
-			wantExt: "gz",
+			wantExt: ".gz",
 		},
 	}
 	for _, tt := range tests {
@@ -147,21 +147,21 @@ func TestStored(t *testing.T) {
 			stored:  Stored{Encoding: GZip},
 			wantOk:  false,
 			wantStr: "gz",
-			wantExt: "gz",
+			wantExt: ".gz",
 		},
 		{
 			desc:    "type with native encoding",
 			stored:  Stored{Type: JPG},
 			wantOk:  true,
 			wantStr: "jpg",
-			wantExt: "jpg",
+			wantExt: ".jpg",
 		},
 		{
 			desc:    "type with encoding",
 			stored:  Stored{PNG, GZip},
 			wantOk:  true,
 			wantStr: "png.gz",
-			wantExt: "png.gz",
+			wantExt: ".png.gz",
 		},
 	}
 	for _, tt := range tests {
@@ -207,36 +207,41 @@ func TestParseExt(t *testing.T) {
 			want: Stored{},
 		},
 		{
+			desc: "dot",
+			ext:  ".",
+			want: Stored{},
+		},
+		{
 			desc: "just type",
-			ext:  "jpg",
+			ext:  ".jpg",
 			want: Stored{Type: JPG},
 		},
 		{
 			desc:    "just encoding",
-			ext:     "gz",
+			ext:     ".gz",
 			want:    Stored{Encoding: GZip},
 			wantErr: errors.New("data: unknown type: \"gz\""),
 		},
 		{
 			desc: "type and encoding",
-			ext:  "jpg.gz",
+			ext:  ".jpg.gz",
 			want: Stored{JPG, GZip},
 		},
 		{
 			desc:    "unknown type",
-			ext:     "foo.gz",
+			ext:     ".foo.gz",
 			want:    Stored{"foo", GZip},
 			wantErr: errors.New("data: unknown type: \"foo\""),
 		},
 		{
 			desc:    "unknown encoding",
-			ext:     "jpg.foo",
+			ext:     ".jpg.foo",
 			want:    Stored{JPG, "foo"},
 			wantErr: errors.New("data: unknown encoding: \"foo\""),
 		},
 		{
 			desc:    "too many parts (will support this later)",
-			ext:     "jpg.tar.gz",
+			ext:     ".jpg.tar.gz",
 			wantErr: errors.New("data: too many parts in extension \"jpg.tar.gz\""),
 		},
 	}

--- a/data/types_test.go
+++ b/data/types_test.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -13,14 +14,16 @@ func TestType(t *testing.T) {
 		wantOk    bool
 		wantStr   string
 		wantExt   string
+		wantFmtV  string
 		wantClass Class
 	}{
 		{
 			desc:      "Unknown",
 			typ:       UnknownType,
 			wantOk:    false,
-			wantStr:   "data:unknown",
+			wantStr:   "",
 			wantExt:   "",
+			wantFmtV:  "unknown",
 			wantClass: Unclassified,
 		},
 		{
@@ -29,6 +32,7 @@ func TestType(t *testing.T) {
 			wantOk:    false,
 			wantStr:   "foo",
 			wantExt:   ".foo",
+			wantFmtV:  "foo",
 			wantClass: Unclassified,
 		},
 		{
@@ -37,6 +41,7 @@ func TestType(t *testing.T) {
 			wantOk:    true,
 			wantStr:   "jpg",
 			wantExt:   ".jpg",
+			wantFmtV:  "jpg",
 			wantClass: Image,
 		},
 		{
@@ -45,6 +50,7 @@ func TestType(t *testing.T) {
 			wantOk:    true,
 			wantStr:   "png",
 			wantExt:   ".png",
+			wantFmtV:  "png",
 			wantClass: Image,
 		},
 		{
@@ -53,6 +59,7 @@ func TestType(t *testing.T) {
 			wantOk:    true,
 			wantStr:   "gif",
 			wantExt:   ".gif",
+			wantFmtV:  "gif",
 			wantClass: Image,
 		},
 	}
@@ -70,45 +77,53 @@ func TestType(t *testing.T) {
 			if got, want := tt.typ.Class(), tt.wantClass; got != want {
 				t.Errorf("Class got %q want %q", got, want)
 			}
+			if got, want := fmt.Sprintf("%v", tt.typ), tt.wantFmtV; got != want {
+				t.Errorf("%%v got %q want %q", got, want)
+			}
 		})
 	}
 }
 
 func TestEncoding(t *testing.T) {
 	tests := []struct {
-		desc    string
-		enc     Encoding
-		wantOk  bool
-		wantStr string
-		wantExt string
+		desc     string
+		enc      Encoding
+		wantOk   bool
+		wantStr  string
+		wantExt  string
+		wantFmtV string
 	}{
 		{
-			desc:    "native",
-			enc:     Native,
-			wantOk:  true,
-			wantStr: "data:native",
-			wantExt: "",
+			desc:     "native",
+			enc:      Native,
+			wantOk:   true,
+			wantStr:  "",
+			wantExt:  "",
+			wantFmtV: "native",
 		},
 		{
-			desc:    "undefined",
-			enc:     "foo",
-			wantOk:  false,
-			wantStr: "foo",
-			wantExt: ".foo",
+			desc:     "undefined",
+			enc:      "foo",
+			wantOk:   false,
+			wantStr:  "foo",
+			wantExt:  ".foo",
+			wantFmtV: "foo",
 		},
 		{
-			desc:    "tar",
-			enc:     Tar,
-			wantOk:  true,
-			wantStr: "tar",
-			wantExt: ".tar",
+			desc:     "tar",
+			enc:      Tar,
+			wantOk:   true,
+			wantStr:  "tar",
+			wantExt:  ".tar",
+			wantFmtV: "tar",
 		},
 		{
-			desc:    "gzip",
-			enc:     GZip,
-			wantOk:  true,
-			wantStr: "gz",
-			wantExt: ".gz",
+			desc:     "gzip",
+			enc:      GZip,
+			wantOk:   true,
+			wantStr:  "gz",
+			wantExt:  ".gz",
+			wantFmtV: "gz",
 		},
 	}
 	for _, tt := range tests {
@@ -122,46 +137,53 @@ func TestEncoding(t *testing.T) {
 			if got, want := tt.enc.Ext(), tt.wantExt; got != want {
 				t.Errorf("Ext got %q want %q", got, want)
 			}
+			if got, want := fmt.Sprintf("%v", tt.enc), tt.wantFmtV; got != want {
+				t.Errorf("%%v got %q want %q", got, want)
+			}
 		})
 	}
 }
 
 func TestStored(t *testing.T) {
 	tests := []struct {
-		desc      string
-		stored    Stored
-		wantOk    bool
-		wantStr   string
-		wantExt   string
-		wantClass Class
+		desc     string
+		stored   Stored
+		wantOk   bool
+		wantStr  string
+		wantExt  string
+		wantFmtV string
 	}{
 		{
-			desc:    "zero value",
-			stored:  Stored{},
-			wantOk:  false,
-			wantStr: "data:unknown",
-			wantExt: "",
+			desc:     "zero value",
+			stored:   Stored{},
+			wantOk:   false,
+			wantStr:  "",
+			wantExt:  "",
+			wantFmtV: "Stored[type: unknown, encoding: native]",
 		},
 		{
-			desc:    "unknown type",
-			stored:  Stored{Encoding: GZip},
-			wantOk:  false,
-			wantStr: "gz",
-			wantExt: ".gz",
+			desc:     "unknown type",
+			stored:   Stored{Encoding: GZip},
+			wantOk:   false,
+			wantStr:  "gz",
+			wantExt:  ".gz",
+			wantFmtV: "Stored[type: unknown, encoding: gz]",
 		},
 		{
-			desc:    "type with native encoding",
-			stored:  Stored{Type: JPG},
-			wantOk:  true,
-			wantStr: "jpg",
-			wantExt: ".jpg",
+			desc:     "type with native encoding",
+			stored:   Stored{Type: JPG},
+			wantOk:   true,
+			wantStr:  "jpg",
+			wantExt:  ".jpg",
+			wantFmtV: "Stored[type: jpg, encoding: native]",
 		},
 		{
-			desc:    "type with encoding",
-			stored:  Stored{PNG, GZip},
-			wantOk:  true,
-			wantStr: "png.gz",
-			wantExt: ".png.gz",
+			desc:     "type with encoding",
+			stored:   Stored{PNG, GZip},
+			wantOk:   true,
+			wantStr:  "png.gz",
+			wantExt:  ".png.gz",
+			wantFmtV: "Stored[type: png, encoding: gz]",
 		},
 	}
 	for _, tt := range tests {
@@ -175,26 +197,29 @@ func TestStored(t *testing.T) {
 			if got, want := tt.stored.Ext(), tt.wantExt; got != want {
 				t.Errorf("Ext got %q want %q", got, want)
 			}
+			if got, want := fmt.Sprintf("%v", tt.stored), tt.wantFmtV; got != want {
+				t.Errorf("%%v got %q want %q", got, want)
+			}
 			ext := tt.stored.Ext()
 			if tt.wantOk {
-				got, err := ParseExt(ext)
+				got, err := ParseType(ext)
 				if err != nil {
-					t.Errorf("ParseExt round trip: %s", err)
+					t.Errorf("ParseType round trip: %s", err)
 				}
 				if got != tt.stored {
-					t.Errorf("ParseExt got %v want %v", got, tt.stored)
+					t.Errorf("ParseType got %v want %v", got, tt.stored)
 				}
 			} else if ext != "" {
-				_, err := ParseExt(ext)
+				_, err := ParseType(ext)
 				if err == nil {
-					t.Errorf("ParseExt must fail if not empty and not ok: %s", ext)
+					t.Errorf("ParseType must fail if not empty and not ok: %s", ext)
 				}
 			}
 		})
 	}
 }
 
-func TestParseExt(t *testing.T) {
+func TestParseType(t *testing.T) {
 	tests := []struct {
 		desc    string
 		ext     string
@@ -212,47 +237,58 @@ func TestParseExt(t *testing.T) {
 			want: Stored{},
 		},
 		{
-			desc: "just type",
+			desc: "type",
+			ext:  "jpg",
+			want: Stored{Type: JPG},
+		},
+		{
+			desc: "type extension",
 			ext:  ".jpg",
 			want: Stored{Type: JPG},
 		},
 		{
-			desc:    "just encoding",
+			desc:    "encoding",
+			ext:     "gz",
+			want:    Stored{Encoding: GZip},
+			wantErr: errors.New("data: unknown type: gz"),
+		},
+		{
+			desc:    "encoding extension",
 			ext:     ".gz",
 			want:    Stored{Encoding: GZip},
-			wantErr: errors.New("data: unknown type: \"gz\""),
+			wantErr: errors.New("data: unknown type: gz"),
 		},
 		{
 			desc: "type and encoding",
-			ext:  ".jpg.gz",
+			ext:  "jpg.gz",
 			want: Stored{JPG, GZip},
 		},
 		{
 			desc:    "unknown type",
-			ext:     ".foo.gz",
+			ext:     "foo.gz",
 			want:    Stored{"foo", GZip},
-			wantErr: errors.New("data: unknown type: \"foo\""),
+			wantErr: errors.New("data: unknown type: foo"),
 		},
 		{
 			desc:    "unknown encoding",
-			ext:     ".jpg.foo",
+			ext:     "jpg.foo",
 			want:    Stored{JPG, "foo"},
-			wantErr: errors.New("data: unknown encoding: \"foo\""),
+			wantErr: errors.New("data: unknown encoding: foo"),
 		},
 		{
 			desc:    "too many parts (will support this later)",
-			ext:     ".jpg.tar.gz",
+			ext:     "jpg.tar.gz",
 			wantErr: errors.New("data: too many parts in extension \"jpg.tar.gz\""),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			got, err := ParseExt(tt.ext)
+			got, err := ParseType(tt.ext)
 			if !reflect.DeepEqual(err, tt.wantErr) {
-				t.Fatalf("ParseExt got err %q want %q", err, tt.wantErr)
+				t.Fatalf("ParseType got err %q want %q", err, tt.wantErr)
 			}
 			if got != tt.want {
-				t.Fatalf("ParseExt got %v want %v", got, tt.want)
+				t.Fatalf("ParseType got %v want %v", got, tt.want)
 			}
 		})
 	}

--- a/data/types_test.go
+++ b/data/types_test.go
@@ -1,6 +1,8 @@
 package data
 
 import (
+	"errors"
+	"reflect"
 	"testing"
 )
 
@@ -49,6 +51,44 @@ func TestType(t *testing.T) {
 	}
 }
 
+func TestEncoding(t *testing.T) {
+	tests := []struct {
+		desc    string
+		enc     Encoding
+		wantStr string
+		wantExt string
+	}{
+		{
+			desc:    "native",
+			enc:     Native,
+			wantStr: "<native>",
+			wantExt: "",
+		},
+		{
+			desc:    "tar",
+			enc:     Tar,
+			wantStr: "tar",
+			wantExt: "tar",
+		},
+		{
+			desc:    "gzip",
+			enc:     GZip,
+			wantStr: "gz",
+			wantExt: "gz",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			if got, want := tt.enc.String(), tt.wantStr; got != want {
+				t.Errorf("String got %q want %q", got, want)
+			}
+			if got, want := tt.enc.Ext(), tt.wantExt; got != want {
+				t.Errorf("Ext got %q want %q", got, want)
+			}
+		})
+	}
+}
+
 func TestStored(t *testing.T) {
 	tests := []struct {
 		desc      string
@@ -77,6 +117,62 @@ func TestStored(t *testing.T) {
 			}
 			if got, want := tt.stored.Ext(), tt.wantExt; got != want {
 				t.Errorf("Ext got %q want %q", got, want)
+			}
+			got, err := ParseExt(tt.stored.String())
+			if err != nil {
+				t.Errorf("ParseExt round trip: %s", err)
+			}
+			if got != tt.stored {
+				t.Errorf("ParseExt got %s want %s", got, tt.stored)
+			}
+		})
+	}
+}
+
+func TestParseExt(t *testing.T) {
+	tests := []struct {
+		desc    string
+		ext     string
+		want    Stored
+		wantErr error
+	}{
+		{
+
+			desc: "just type",
+			ext:  "jpg",
+			want: Stored{JPG, Native},
+		},
+		{
+			desc: "type and encoding",
+			ext:  "jpg.gz",
+			want: Stored{JPG, GZip},
+		},
+		{
+			// NOTE: being generous for now. could definitely reconsider this.
+			desc: "unknown type is allowed",
+			ext:  "foo.gz",
+			want: Stored{"foo", GZip},
+		},
+		{
+			// NOTE: being generous for now. could definitely reconsider this.
+			desc: "unknown encoding is allowed",
+			ext:  "jpg.foo",
+			want: Stored{JPG, "foo"},
+		},
+		{
+			desc:    "too many parts (will support this later)",
+			ext:     "jpg.tar.gz",
+			wantErr: errors.New("data: too many parts in extension \"jpg.tar.gz\""),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got, err := ParseExt(tt.ext)
+			if !reflect.DeepEqual(err, tt.wantErr) {
+				t.Fatalf("ParseExt got err %q want %q", got, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseExt got %q want %q", got, tt.want)
 			}
 		})
 	}

--- a/data/types_test.go
+++ b/data/types_test.go
@@ -10,13 +10,31 @@ func TestType(t *testing.T) {
 	tests := []struct {
 		desc      string
 		typ       Type
+		wantOk    bool
 		wantStr   string
 		wantExt   string
 		wantClass Class
 	}{
 		{
+			desc:      "Unknown",
+			typ:       UnknownType,
+			wantOk:    false,
+			wantStr:   "data:unknown",
+			wantExt:   "",
+			wantClass: Unclassified,
+		},
+		{
+			desc:      "other",
+			typ:       "foo",
+			wantOk:    false,
+			wantStr:   "foo",
+			wantExt:   "foo",
+			wantClass: Unclassified,
+		},
+		{
 			desc:      "jpg",
 			typ:       JPG,
+			wantOk:    true,
 			wantStr:   "jpg",
 			wantExt:   "jpg",
 			wantClass: Image,
@@ -24,6 +42,7 @@ func TestType(t *testing.T) {
 		{
 			desc:      "png",
 			typ:       PNG,
+			wantOk:    true,
 			wantStr:   "png",
 			wantExt:   "png",
 			wantClass: Image,
@@ -31,6 +50,7 @@ func TestType(t *testing.T) {
 		{
 			desc:      "gif",
 			typ:       GIF,
+			wantOk:    true,
 			wantStr:   "gif",
 			wantExt:   "gif",
 			wantClass: Image,
@@ -38,6 +58,9 @@ func TestType(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
+			if got, want := tt.typ.Ok(), tt.wantOk; got != want {
+				t.Errorf("Ok() got %t want %t", got, want)
+			}
 			if got, want := tt.typ.String(), tt.wantStr; got != want {
 				t.Errorf("String got %q want %q", got, want)
 			}
@@ -55,30 +78,44 @@ func TestEncoding(t *testing.T) {
 	tests := []struct {
 		desc    string
 		enc     Encoding
+		wantOk  bool
 		wantStr string
 		wantExt string
 	}{
 		{
 			desc:    "native",
 			enc:     Native,
-			wantStr: "<native>",
+			wantOk:  true,
+			wantStr: "data:native",
 			wantExt: "",
+		},
+		{
+			desc:    "undefined",
+			enc:     "foo",
+			wantOk:  false,
+			wantStr: "foo",
+			wantExt: "foo",
 		},
 		{
 			desc:    "tar",
 			enc:     Tar,
+			wantOk:  true,
 			wantStr: "tar",
 			wantExt: "tar",
 		},
 		{
 			desc:    "gzip",
 			enc:     GZip,
+			wantOk:  true,
 			wantStr: "gz",
 			wantExt: "gz",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
+			if got, want := tt.enc.Ok(), tt.wantOk; got != want {
+				t.Errorf("Ok() got %t want %t", got, want)
+			}
 			if got, want := tt.enc.String(), tt.wantStr; got != want {
 				t.Errorf("String got %q want %q", got, want)
 			}
@@ -93,37 +130,58 @@ func TestStored(t *testing.T) {
 	tests := []struct {
 		desc      string
 		stored    Stored
+		wantOk    bool
 		wantStr   string
 		wantExt   string
 		wantClass Class
 	}{
 		{
-			desc:    "native encoding",
-			stored:  Stored{JPG, Native},
+			desc:    "zero value",
+			stored:  Stored{},
+			wantOk:  false,
+			wantStr: "data:unknown",
+			wantExt: "",
+		},
+		{
+			desc:    "unknown type",
+			stored:  Stored{Encoding: GZip},
+			wantOk:  false,
+			wantStr: "gz",
+			wantExt: "gz",
+		},
+		{
+			desc:    "type with native encoding",
+			stored:  Stored{Type: JPG},
+			wantOk:  true,
 			wantStr: "jpg",
 			wantExt: "jpg",
 		},
 		{
-			desc:    "with encoding",
+			desc:    "type with encoding",
 			stored:  Stored{PNG, GZip},
+			wantOk:  true,
 			wantStr: "png.gz",
 			wantExt: "png.gz",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
+			if got, want := tt.stored.Ok(), tt.wantOk; got != want {
+				t.Errorf("Ok() got %t want %t", got, want)
+			}
 			if got, want := tt.stored.String(), tt.wantStr; got != want {
 				t.Errorf("String got %q want %q", got, want)
 			}
 			if got, want := tt.stored.Ext(), tt.wantExt; got != want {
 				t.Errorf("Ext got %q want %q", got, want)
 			}
-			got, err := ParseExt(tt.stored.String())
+			ext := tt.stored.Ext()
+			got, err := ParseExt(ext)
 			if err != nil {
 				t.Errorf("ParseExt round trip: %s", err)
 			}
 			if got != tt.stored {
-				t.Errorf("ParseExt got %s want %s", got, tt.stored)
+				t.Errorf("ParseExt got %v want %v", got, tt.stored)
 			}
 		})
 	}
@@ -148,16 +206,16 @@ func TestParseExt(t *testing.T) {
 			want: Stored{JPG, GZip},
 		},
 		{
-			// NOTE: being generous for now. could definitely reconsider this.
-			desc: "unknown type is allowed",
-			ext:  "foo.gz",
-			want: Stored{"foo", GZip},
+			desc:    "unknown type",
+			ext:     "foo.gz",
+			want:    Stored{"foo", GZip},
+			wantErr: errors.New("data: unknown type: \"foo\""),
 		},
 		{
-			// NOTE: being generous for now. could definitely reconsider this.
-			desc: "unknown encoding is allowed",
-			ext:  "jpg.foo",
-			want: Stored{JPG, "foo"},
+			desc:    "unknown encoding",
+			ext:     "jpg.foo",
+			want:    Stored{JPG, "foo"},
+			wantErr: errors.New("data: unknown encoding: \"foo\""),
 		},
 		{
 			desc:    "too many parts (will support this later)",
@@ -169,10 +227,10 @@ func TestParseExt(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			got, err := ParseExt(tt.ext)
 			if !reflect.DeepEqual(err, tt.wantErr) {
-				t.Fatalf("ParseExt got err %q want %q", got, tt.wantErr)
+				t.Fatalf("ParseExt got err %q want %q", err, tt.wantErr)
 			}
 			if got != tt.want {
-				t.Fatalf("ParseExt got %q want %q", got, tt.want)
+				t.Fatalf("ParseExt got %v want %v", got, tt.want)
 			}
 		})
 	}

--- a/data/types_test.go
+++ b/data/types_test.go
@@ -148,6 +148,7 @@ func TestStored(t *testing.T) {
 	tests := []struct {
 		desc     string
 		stored   Stored
+		wantZero bool
 		wantOk   bool
 		wantStr  string
 		wantExt  string
@@ -157,6 +158,7 @@ func TestStored(t *testing.T) {
 			desc:     "zero value",
 			stored:   Stored{},
 			wantOk:   false,
+			wantZero: true,
 			wantStr:  "",
 			wantExt:  "",
 			wantFmtV: "Stored[type: unknown, encoding: native]",
@@ -188,6 +190,9 @@ func TestStored(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
+			if got, want := tt.stored.IsZero(), tt.wantZero; got != want {
+				t.Errorf("IsZero() got %t want %t", got, want)
+			}
 			if got, want := tt.stored.Ok(), tt.wantOk; got != want {
 				t.Errorf("Ok() got %t want %t", got, want)
 			}

--- a/data/types_test.go
+++ b/data/types_test.go
@@ -176,12 +176,19 @@ func TestStored(t *testing.T) {
 				t.Errorf("Ext got %q want %q", got, want)
 			}
 			ext := tt.stored.Ext()
-			got, err := ParseExt(ext)
-			if err != nil {
-				t.Errorf("ParseExt round trip: %s", err)
-			}
-			if got != tt.stored {
-				t.Errorf("ParseExt got %v want %v", got, tt.stored)
+			if tt.wantOk {
+				got, err := ParseExt(ext)
+				if err != nil {
+					t.Errorf("ParseExt round trip: %s", err)
+				}
+				if got != tt.stored {
+					t.Errorf("ParseExt got %v want %v", got, tt.stored)
+				}
+			} else if ext != "" {
+				_, err := ParseExt(ext)
+				if err == nil {
+					t.Errorf("ParseExt must fail if not empty and not ok: %s", ext)
+				}
 			}
 		})
 	}
@@ -195,14 +202,20 @@ func TestParseExt(t *testing.T) {
 		wantErr error
 	}{
 		{
+			desc: "empty string",
+			ext:  "",
+			want: Stored{},
+		},
+		{
 			desc: "just type",
 			ext:  "jpg",
 			want: Stored{Type: JPG},
 		},
 		{
-			desc: "just encoding",
-			ext:  "gz",
-			want: Stored{Encoding: GZip},
+			desc:    "just encoding",
+			ext:     "gz",
+			want:    Stored{Encoding: GZip},
+			wantErr: errors.New("data: unknown type: \"gz\""),
 		},
 		{
 			desc: "type and encoding",

--- a/data/types_test.go
+++ b/data/types_test.go
@@ -1,0 +1,83 @@
+package data
+
+import (
+	"testing"
+)
+
+func TestType(t *testing.T) {
+	tests := []struct {
+		desc      string
+		typ       Type
+		wantStr   string
+		wantExt   string
+		wantClass Class
+	}{
+		{
+			desc:      "jpg",
+			typ:       JPG,
+			wantStr:   "jpg",
+			wantExt:   "jpg",
+			wantClass: Image,
+		},
+		{
+			desc:      "png",
+			typ:       PNG,
+			wantStr:   "png",
+			wantExt:   "png",
+			wantClass: Image,
+		},
+		{
+			desc:      "gif",
+			typ:       GIF,
+			wantStr:   "gif",
+			wantExt:   "gif",
+			wantClass: Image,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			if got, want := tt.typ.String(), tt.wantStr; got != want {
+				t.Errorf("String got %q want %q", got, want)
+			}
+			if got, want := tt.typ.Ext(), tt.wantExt; got != want {
+				t.Errorf("Ext got %q want %q", got, want)
+			}
+			if got, want := tt.typ.Class(), tt.wantClass; got != want {
+				t.Errorf("Class got %q want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestStored(t *testing.T) {
+	tests := []struct {
+		desc      string
+		stored    Stored
+		wantStr   string
+		wantExt   string
+		wantClass Class
+	}{
+		{
+			desc:    "native encoding",
+			stored:  Stored{JPG, Native},
+			wantStr: "jpg",
+			wantExt: "jpg",
+		},
+		{
+			desc:    "with encoding",
+			stored:  Stored{PNG, GZip},
+			wantStr: "png.gz",
+			wantExt: "png.gz",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			if got, want := tt.stored.String(), tt.wantStr; got != want {
+				t.Errorf("String got %q want %q", got, want)
+			}
+			if got, want := tt.stored.Ext(), tt.wantExt; got != want {
+				t.Errorf("Ext got %q want %q", got, want)
+			}
+		})
+	}
+}

--- a/dst/layout.go
+++ b/dst/layout.go
@@ -98,12 +98,12 @@ func (l fsLayout) DataURI(hash data.Hash, meta *meta.Meta) uri.URI {
 	case "media":
 		t := meta.Inherent.Created
 		if t.IsZero() {
-			key = fmt.Sprintf("%s/%s/%s.%s", category, l.zeroDateDir, l.dirs(hash), ext)
+			key = fmt.Sprintf("%s/%s/%s%s", category, l.zeroDateDir, l.dirs(hash), ext)
 			return uri.TrustedNew(key)
 		}
 		year := t.Format("2006")
 		date := t.Format("2006-01-02")
-		key = fmt.Sprintf("%s/%s/%s/%s.%s", category, year, date, hash.String(), ext)
+		key = fmt.Sprintf("%s/%s/%s/%s%s", category, year, date, hash.String(), ext)
 		return uri.TrustedNew(key)
 
 	// Otherwise organize by breaking down the hash.
@@ -111,7 +111,7 @@ func (l fsLayout) DataURI(hash data.Hash, meta *meta.Meta) uri.URI {
 		if ext == "" {
 			key = fmt.Sprintf("%s/%s", category, l.dirs(hash))
 		} else {
-			key = fmt.Sprintf("%s/%s.%s", category, l.dirs(hash), ext)
+			key = fmt.Sprintf("%s/%s%s", category, l.dirs(hash), ext)
 		}
 		return uri.TrustedNew(key)
 	}

--- a/examples/index/main.go
+++ b/examples/index/main.go
@@ -154,7 +154,7 @@ func buildDstItem(layout dst.Layout, dst index.Dst, hash data.Hash, meta *meta.M
 		DstID:     dst.DstID,
 		DataURI:   dataURI,
 		MetaURI:   metaURI,
-		DataType:  data.Stored{Type: data.JPG},
+		DataType:  data.Stored{Type: meta.Type},
 		DataSize:  0, // updated with actual data size
 		MetaSize:  0, // updated with actual meta size
 		StoredAt:  time.Date(2018, 11, 13, 0, 0, 0, 0, time.UTC),

--- a/examples/index/main.go
+++ b/examples/index/main.go
@@ -154,6 +154,7 @@ func buildDstItem(layout dst.Layout, dst index.Dst, hash data.Hash, meta *meta.M
 		DstID:     dst.DstID,
 		DataURI:   dataURI,
 		MetaURI:   metaURI,
+		DataType:  data.Stored{Type: data.JPG},
 		DataSize:  0, // updated with actual data size
 		MetaSize:  0, // updated with actual meta size
 		StoredAt:  time.Date(2018, 11, 13, 0, 0, 0, 0, time.UTC),

--- a/examples/index/output.json
+++ b/examples/index/output.json
@@ -30,6 +30,7 @@
           "dst_id": "0e73b6c5-26dc-58a6-8fa9-edd5be9ad99d",
           "data_uri": "media/2018/2018-11-10/f6cf14423780c715b3812bed6295babef572ed56.jpg",
           "meta_uri": "meta/f6/cf/14423780c715b3812bed6295babef572ed56.json",
+          "data_type": "jpg",
           "data_size": 2000,
           "meta_size": 84,
           "stored_at": "2018-11-13T00:00:00Z",

--- a/index/dst.go
+++ b/index/dst.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/recentralized/structure/data"
 	"github.com/recentralized/structure/uri"
 	"github.com/satori/go.uuid"
 )
@@ -85,6 +86,12 @@ type DstItem struct {
 	// typically a URL pointing to the storage location of the metadata.
 	// The URI is always relative resolved to absolute using Dst.MetaURI.
 	MetaURI uri.URI
+
+	// DataType is the type of data that's stored. This field is useful to
+	// filter on a type of data without accessing the meta. It is normally
+	// the type of the original data but could be otherwise if the data has
+	// been compressed on storage, for example.
+	DataType data.Stored
 
 	// DataSize is the size of the stored data in bytes. This field is
 	// useful to calculate things like storage and transfer costs. It will

--- a/index/encoding.go
+++ b/index/encoding.go
@@ -114,6 +114,7 @@ type dstItemJSON struct {
 	DstID     DstID      `json:"dst_id"`
 	DataURI   uri.URI    `json:"data_uri"`
 	MetaURI   uri.URI    `json:"meta_uri"`
+	DataType  string     `json:"data_type,omitempty"`
 	DataSize  int64      `json:"data_size,omitempty"`
 	MetaSize  int64      `json:"meta_size,omitempty"`
 	StoredAt  *time.Time `json:"stored_at,omitempty"`
@@ -126,6 +127,7 @@ func (d DstItem) MarshalJSON() ([]byte, error) {
 		DstID:    d.DstID,
 		DataURI:  d.DataURI,
 		MetaURI:  d.MetaURI,
+		DataType: d.DataType.Ext(),
 		DataSize: d.DataSize,
 		MetaSize: d.MetaSize,
 	}
@@ -149,6 +151,12 @@ func (d *DstItem) UnmarshalJSON(b []byte) error {
 	d.MetaURI = dj.MetaURI
 	d.DataSize = dj.DataSize
 	d.MetaSize = dj.MetaSize
+	if t, err := data.ParseExt(dj.DataType); true {
+		if err != nil {
+			return err
+		}
+		d.DataType = t
+	}
 	if dj.StoredAt != nil {
 		d.StoredAt = *dj.StoredAt
 	}

--- a/index/encoding.go
+++ b/index/encoding.go
@@ -127,7 +127,7 @@ func (d DstItem) MarshalJSON() ([]byte, error) {
 		DstID:    d.DstID,
 		DataURI:  d.DataURI,
 		MetaURI:  d.MetaURI,
-		DataType: d.DataType.Ext(),
+		DataType: d.DataType.String(),
 		DataSize: d.DataSize,
 		MetaSize: d.MetaSize,
 	}
@@ -149,14 +149,13 @@ func (d *DstItem) UnmarshalJSON(b []byte) error {
 	d.DstID = dj.DstID
 	d.DataURI = dj.DataURI
 	d.MetaURI = dj.MetaURI
+	typ, err := data.ParseType(dj.DataType)
+	if err != nil {
+		return err
+	}
+	d.DataType = typ
 	d.DataSize = dj.DataSize
 	d.MetaSize = dj.MetaSize
-	if t, err := data.ParseExt(dj.DataType); true {
-		if err != nil {
-			return err
-		}
-		d.DataType = t
-	}
 	if dj.StoredAt != nil {
 		d.StoredAt = *dj.StoredAt
 	}

--- a/index/encoding_test.go
+++ b/index/encoding_test.go
@@ -154,12 +154,13 @@ func TestDstItemJSON(t *testing.T) {
 				DstID:     DstID("abc"),
 				DataURI:   uri.TrustedNew("http://example.com/data/abc.jpg"),
 				MetaURI:   uri.TrustedNew("http://example.com/meta/abc.json"),
+				DataType:  data.Stored{Type: data.JPG},
 				DataSize:  100,
 				MetaSize:  10,
 				StoredAt:  time.Date(1, 2, 3, 4, 5, 6, 7, time.UTC),
 				UpdatedAt: time.Date(2, 2, 3, 4, 5, 6, 7, time.UTC),
 			},
-			json: `{"dst_id":"abc","data_uri":"http://example.com/data/abc.jpg","meta_uri":"http://example.com/meta/abc.json","data_size":100,"meta_size":10,"stored_at":"0001-02-03T04:05:06.000000007Z","updated_at":"0002-02-03T04:05:06.000000007Z"}`,
+			json: `{"dst_id":"abc","data_uri":"http://example.com/data/abc.jpg","meta_uri":"http://example.com/meta/abc.json","data_type":"jpg","data_size":100,"meta_size":10,"stored_at":"0001-02-03T04:05:06.000000007Z","updated_at":"0002-02-03T04:05:06.000000007Z"}`,
 		},
 	}
 	for _, tt := range tests {
@@ -211,6 +212,7 @@ func TestURefJSON(t *testing.T) {
 						DstID:     DstID("abc"),
 						DataURI:   uri.TrustedNew("http://example.com/data/abc.jpg"),
 						MetaURI:   uri.TrustedNew("http://example.com/meta/abc.json"),
+						DataType:  data.Stored{Type: data.JPG},
 						DataSize:  100,
 						MetaSize:  10,
 						StoredAt:  time.Date(1, 2, 3, 4, 5, 6, 7, time.UTC),
@@ -218,7 +220,7 @@ func TestURefJSON(t *testing.T) {
 					},
 				},
 			},
-			json: `{"hash":"xyz","srcs":[{"src_id":"a","data_uri":"http://example.com/data.jpg","meta_uri":"http://example.com/meta.json","modified_at":"2015-02-03T04:05:06.000000007Z"}],"dsts":[{"dst_id":"abc","data_uri":"http://example.com/data/abc.jpg","meta_uri":"http://example.com/meta/abc.json","data_size":100,"meta_size":10,"stored_at":"0001-02-03T04:05:06.000000007Z","updated_at":"0002-02-03T04:05:06.000000007Z"}]}`,
+			json: `{"hash":"xyz","srcs":[{"src_id":"a","data_uri":"http://example.com/data.jpg","meta_uri":"http://example.com/meta.json","modified_at":"2015-02-03T04:05:06.000000007Z"}],"dsts":[{"dst_id":"abc","data_uri":"http://example.com/data/abc.jpg","meta_uri":"http://example.com/meta/abc.json","data_type":"jpg","data_size":100,"meta_size":10,"stored_at":"0001-02-03T04:05:06.000000007Z","updated_at":"0002-02-03T04:05:06.000000007Z"}]}`,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This adds the type of stored data to the index. The rationale is that it's useful to have a description of how the bytes are stored on disk along with the URI so that you can know what you're getting back.

Implementation:

I've cleaned up `data.Type` and supporting code to implement the idea of "type + encoding." The idea is that each piece of data must have a format (JPG, PNG, etc) and MAY have an encoding. Encoding is things like tar, gzip, etc - basically ways to store the actual data on disk in more efficient ways. Type + Encoding can be represented as `<type>[.<encoding>]` - formatted and parsed. 

The type that implements this combination is `data.Stored`. It's important to note that this is separate from `data.Type` which is still used as the field on `Meta` - the type of the stored data, independent of how it's represented on disk.