### PR TITLE
Instagram metadata

### DIFF
--- a/meta/instagram.go
+++ b/meta/instagram.go
@@ -1,0 +1,64 @@
+package meta
+
+import "time"
+
+// InstagramMedia is the full set of data available for media on Instagram.
+// https://www.instagram.com/developer/
+type InstagramMedia struct {
+
+	// Media ID
+	ID string
+
+	// If the media is part of a multi-media post like a carousel, this is
+	// the position of this individual piece of media.
+	Multiple bool
+	Position int
+
+	// Public URL
+	Link string
+
+	// Basic information when posted.
+	User      InstagramUser
+	Location  InstagramLocation
+	Caption   string
+	CreatedAt time.Time
+
+	// Additional information when posted.
+	Filter      string
+	Tags        []string
+	TaggedUsers []InstagramTaggedUser
+
+	// User activity.
+	Likes    int
+	Comments []InstagramComment
+}
+
+// InstagramUser describes a user on Instagram.
+type InstagramUser struct {
+	ID       string
+	Username string
+	FullName string
+}
+
+// InstagramLocation describes geo location of an Instagram post.
+type InstagramLocation struct {
+	ID        string
+	Name      string
+	Latitude  float64
+	Longitude float64
+}
+
+// InstagramComment is a comment on an Instagram post.
+type InstagramComment struct {
+	ID   string
+	Text string
+	Date time.Time
+	From InstagramUser
+}
+
+//InstagramTaggedUser is a user tagged in media.
+type InstagramTaggedUser struct {
+	Username string
+	X        float64
+	Y        float64
+}

--- a/meta/instagram.go
+++ b/meta/instagram.go
@@ -54,7 +54,7 @@ type InstagramComment struct {
 	Date     *time.Time `json:"date,omitempty"`
 }
 
-//InstagramTaggedUser is a user tagged in media.
+// InstagramTaggedUser is a user tagged in media.
 type InstagramTaggedUser struct {
 	Username string  `json:"username"`
 	X        float64 `json:"x"`

--- a/meta/instagram.go
+++ b/meta/instagram.go
@@ -15,29 +15,26 @@ type InstagramMedia struct {
 	Position int  `json:"position,omitempty"`
 
 	// Public URL
-	Link string `json:"link"`
+	URL string `json:"url,omitempty"`
+
+	// User that posted it.
+	UserID       string `json:"user_id,omitempty"`
+	Username     string `json:"username,omitempty"`
+	UserFullName string `json:"user_full_name,omitempty"`
 
 	// Basic information when posted.
-	User      *InstagramUser     `json:"user,omitempty"`
-	Location  *InstagramLocation `json:"location,omitempty"`
-	Caption   string             `json:"caption,omitempty"`
-	CreatedAt time.Time          `json:"created_at"`
+	Caption   string     `json:"caption,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// Additional information when posted.
 	Filter      string                `json:"filter,omitempty"`
 	Tags        []string              `json:"tags,omitempty"`
 	TaggedUsers []InstagramTaggedUser `json:"tagged_users,omitempty"`
+	Location    *InstagramLocation    `json:"location,omitempty"`
 
 	// User activity.
-	Likes    int                `json:"likes"`
+	Likes    int                `json:"likes,omitempty"`
 	Comments []InstagramComment `json:"comments,omitempty"`
-}
-
-// InstagramUser describes a user on Instagram.
-type InstagramUser struct {
-	ID       string `json:"id"`
-	Username string `json:"username"`
-	FullName string `json:"full_name,omitempty"`
 }
 
 // InstagramLocation describes geo location of an Instagram post.

--- a/meta/instagram.go
+++ b/meta/instagram.go
@@ -7,58 +7,58 @@ import "time"
 type InstagramMedia struct {
 
 	// Media ID
-	ID string
+	ID string `json:"id"`
 
 	// If the media is part of a multi-media post like a carousel, this is
 	// the position of this individual piece of media.
-	Multiple bool
-	Position int
+	Multiple bool `json:"multiple,omitempty"`
+	Position int  `json:"position,omitempty"`
 
 	// Public URL
-	Link string
+	Link string `json:"link"`
 
 	// Basic information when posted.
-	User      InstagramUser
-	Location  InstagramLocation
-	Caption   string
-	CreatedAt time.Time
+	User      *InstagramUser     `json:"user,omitempty"`
+	Location  *InstagramLocation `json:"location,omitempty"`
+	Caption   string             `json:"caption,omitempty"`
+	CreatedAt time.Time          `json:"created_at"`
 
 	// Additional information when posted.
-	Filter      string
-	Tags        []string
-	TaggedUsers []InstagramTaggedUser
+	Filter      string                `json:"filter,omitempty"`
+	Tags        []string              `json:"tags,omitempty"`
+	TaggedUsers []InstagramTaggedUser `json:"tagged_users,omitempty"`
 
 	// User activity.
-	Likes    int
-	Comments []InstagramComment
+	Likes    int                `json:"likes"`
+	Comments []InstagramComment `json:"comments,omitempty"`
 }
 
 // InstagramUser describes a user on Instagram.
 type InstagramUser struct {
-	ID       string
-	Username string
-	FullName string
+	ID       string `json:"id"`
+	Username string `json:"username"`
+	FullName string `json:"full_name,omitempty"`
 }
 
 // InstagramLocation describes geo location of an Instagram post.
 type InstagramLocation struct {
-	ID        string
-	Name      string
-	Latitude  float64
-	Longitude float64
+	ID        string  `json:"id"`
+	Name      string  `json:"name"`
+	Latitude  float64 `json:"latitude"`
+	Longitude float64 `json:"longitude"`
 }
 
 // InstagramComment is a comment on an Instagram post.
 type InstagramComment struct {
-	ID   string
-	Text string
-	Date time.Time
-	From InstagramUser
+	ID       string    `json:"id"`
+	Text     string    `json:"text"`
+	Username string    `json:"username"`
+	Date     time.Time `json:"date"`
 }
 
 //InstagramTaggedUser is a user tagged in media.
 type InstagramTaggedUser struct {
-	Username string
-	X        float64
-	Y        float64
+	Username string  `json:"username"`
+	X        float64 `json:"x"`
+	Y        float64 `json:"y"`
 }

--- a/meta/instagram.go
+++ b/meta/instagram.go
@@ -33,8 +33,9 @@ type InstagramMedia struct {
 	Location    *InstagramLocation    `json:"location,omitempty"`
 
 	// User activity.
-	Likes    int                `json:"likes,omitempty"`
-	Comments []InstagramComment `json:"comments,omitempty"`
+	LikesCount    int                `json:"likes_count,omitempty"`
+	CommentsCount int                `json:"comments_count,omitempty"`
+	Comments      []InstagramComment `json:"comments,omitempty"`
 }
 
 // InstagramLocation describes geo location of an Instagram post.

--- a/meta/instagram.go
+++ b/meta/instagram.go
@@ -47,10 +47,10 @@ type InstagramLocation struct {
 
 // InstagramComment is a comment on an Instagram post.
 type InstagramComment struct {
-	ID       string    `json:"id"`
-	Text     string    `json:"text"`
-	Username string    `json:"username"`
-	Date     time.Time `json:"date"`
+	ID       string     `json:"id"`
+	Text     string     `json:"text"`
+	Username string     `json:"username,omitempty"`
+	Date     *time.Time `json:"date,omitempty"`
 }
 
 //InstagramTaggedUser is a user tagged in media.

--- a/meta/instagram_test.go
+++ b/meta/instagram_test.go
@@ -90,6 +90,8 @@ func TestInstagramMediaJSON(t *testing.T) {
 			data: &InstagramMedia{
 				ID:           "1979320569926821011_11073382793",
 				URL:          "https://www.instagram.com/p/Bt39ZJLHKSTFwXShw402xx8W9loUPHTyH5BsqY0/",
+				Multiple:     true,
+				Position:     1,
 				UserID:       "11073382793",
 				Username:     "go_ig_test_0219",
 				UserFullName: "Golang Client",
@@ -116,6 +118,8 @@ func TestInstagramMediaJSON(t *testing.T) {
 			json: `{
 			  "id": "1979320569926821011_11073382793",
 			  "url": "https://www.instagram.com/p/Bt39ZJLHKSTFwXShw402xx8W9loUPHTyH5BsqY0/",
+			  "multiple": true,
+			  "position": 1,
 			  "user_id": "11073382793",
 			  "username": "go_ig_test_0219",
 			  "user_full_name": "Golang Client",

--- a/meta/instagram_test.go
+++ b/meta/instagram_test.go
@@ -1,0 +1,149 @@
+package meta
+
+import (
+	"testing"
+	"time"
+)
+
+func TestInstagramJSON(t *testing.T) {
+	tests := []struct {
+		desc string
+		data *InstagramMedia
+		json string
+	}{
+		{
+			desc: "zero value",
+			data: &InstagramMedia{},
+			json: `{"id":""}`,
+		},
+		{
+			desc: "all data",
+			// {
+			//   "id": "1979320569926821011_11073382793",
+			//   "user": {
+			//     "id": "11073382793",
+			//     "full_name": "Golang Client",
+			//     "profile_picture": "https://scontent-sjc3-1.cdninstagram.com/vp/504ac2fa79adb1d412b31cab19be8d36/5CDDD9F1/t51.2885-19/44884218_345707102882519_2446069589734326272_n.jpg?_nc_ht=scontent-sjc3-1.cdninstagram.com",
+			//     "username": "go_ig_test_0219"
+			//   },
+			//   "images": {
+			//     "thumbnail": {
+			//       "width": 150,
+			//       "height": 150,
+			//       "url": "https://scontent.cdninstagram.com/vp/fd0f484647ad37dc3caf0a2cdf37ca16/5CE59582/t51.2885-15/e35/c0.135.1080.1080/s150x150/50552544_116846169429307_872782777322498633_n.jpg?_nc_ht=scontent.cdninstagram.com"
+			//     },
+			//     "low_resolution": {
+			//       "width": 320,
+			//       "height": 400,
+			//       "url": "https://scontent.cdninstagram.com/vp/0eda6589295b6fa43fd5cf2731afd691/5CF9331A/t51.2885-15/e35/p320x320/50552544_116846169429307_872782777322498633_n.jpg?_nc_ht=scontent.cdninstagram.com"
+			//     },
+			//     "standard_resolution": {
+			//       "width": 640,
+			//       "height": 800,
+			//       "url": "https://scontent.cdninstagram.com/vp/bd6167c8e4469e16f2f6c900a62c51b9/5CF7EFF6/t51.2885-15/sh0.08/e35/p640x640/50552544_116846169429307_872782777322498633_n.jpg?_nc_ht=scontent.cdninstagram.com"
+			//     }
+			//   },
+			//   "created_time": "1550173420",
+			//   "caption": {
+			//     "id": "18002756710177046",
+			//     "text": "Photo post #0219test",
+			//     "created_time": "1550173420",
+			//     "from": {
+			//       "id": "11073382793",
+			//       "full_name": "Golang Client",
+			//       "profile_picture": "https://scontent-sjc3-1.cdninstagram.com/vp/504ac2fa79adb1d412b31cab19be8d36/5CDDD9F1/t51.2885-19/44884218_345707102882519_2446069589734326272_n.jpg?_nc_ht=scontent-sjc3-1.cdninstagram.com",
+			//       "username": "go_ig_test_0219"
+			//     }
+			//   },
+			//   "user_has_liked": false,
+			//   "likes": {
+			//     "count": 1
+			//   },
+			//   "tags": [
+			//     "0219test"
+			//   ],
+			//   "filter": "Crema",
+			//   "comments": {
+			//     "count": 2
+			//   },
+			//   "type": "image",
+			//   "link": "https://www.instagram.com/p/Bt39ZJLHKSTFwXShw402xx8W9loUPHTyH5BsqY0/",
+			//   "location": {
+			//     "latitude": 37.8029,
+			//     "longitude": -122.2721,
+			//     "name": "Oakland, California",
+			//     "id": 213051194
+			//   },
+			//   "attribution": null,
+			//   "users_in_photo": [
+			//     {
+			//       "user": {
+			//         "username": "rcarver"
+			//       },
+			//       "position": {
+			//         "x": 0.57568438,
+			//         "y": 0.7938808374
+			//       }
+			//     }
+			//   ]
+			// }
+			data: &InstagramMedia{
+				ID:           "1979320569926821011_11073382793",
+				URL:          "https://www.instagram.com/p/Bt39ZJLHKSTFwXShw402xx8W9loUPHTyH5BsqY0/",
+				UserID:       "11073382793",
+				Username:     "go_ig_test_0219",
+				UserFullName: "Golang Client",
+				Caption:      "Photo post #0219test",
+				CreatedAt:    datePtr(2019, 2, 14, 7, 3, 32, 0, time.UTC),
+				Filter:       "Crema",
+				Tags:         []string{"0219test"},
+				Location: &InstagramLocation{
+					ID:        "213051194",
+					Name:      "Oakland, California",
+					Latitude:  37.8029,
+					Longitude: -122.2721,
+				},
+				Likes: 1,
+				TaggedUsers: []InstagramTaggedUser{
+					{
+						Username: "rcarver",
+						X:        0.57568438,
+						Y:        0.7938808374,
+					},
+				},
+			},
+			json: `{
+			  "id": "1979320569926821011_11073382793",
+			  "url": "https://www.instagram.com/p/Bt39ZJLHKSTFwXShw402xx8W9loUPHTyH5BsqY0/",
+			  "user_id": "11073382793",
+			  "username": "go_ig_test_0219",
+			  "user_full_name": "Golang Client",
+			  "caption": "Photo post #0219test",
+			  "created_at": "2019-02-14T07:03:32Z",
+			  "filter": "Crema",
+			  "tags": [
+			      "0219test"
+			  ],
+			  "location": {
+			    "id": "213051194",
+			    "name": "Oakland, California",
+			    "latitude": 37.8029,
+			    "longitude": -122.2721
+			  },
+			  "likes": 1,
+			  "tagged_users": [
+			    {
+			      "username": "rcarver",
+			      "x": 0.57568438,
+			      "y": 0.7938808374
+			    }
+			  ]
+			}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			assertJSONRoundtrip(t, tt.data, tt.json, &InstagramMedia{})
+		})
+	}
+}

--- a/meta/instagram_test.go
+++ b/meta/instagram_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func TestInstagramJSON(t *testing.T) {
+func TestInstagramMediaJSON(t *testing.T) {
 	tests := []struct {
 		desc string
 		data *InstagramMedia
@@ -144,6 +144,48 @@ func TestInstagramJSON(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			assertJSONRoundtrip(t, tt.data, tt.json, &InstagramMedia{})
+		})
+	}
+}
+
+func TestInstagramCommentJSON(t *testing.T) {
+	tests := []struct {
+		desc string
+		data *InstagramComment
+		json string
+	}{
+		{
+			desc: "zero value",
+			data: &InstagramComment{},
+			json: `{"id":"","text":""}`,
+		},
+		{
+			desc: "all data",
+			// {
+			//   "id": "18034730665003447",
+			//   "from": {
+			//     "username": "rcarver"
+			//   },
+			//   "text": "That’s about right.",
+			//   "created_time": "1550177777"
+			// },
+			data: &InstagramComment{
+				ID:       "18034730665003447",
+				Username: "rcarver",
+				Text:     "That’s about right.",
+				Date:     datePtr(2019, 2, 14, 20, 56, 17, 0, time.UTC),
+			},
+			json: `{
+			  "id": "18034730665003447",
+			  "username": "rcarver",
+			  "text": "That’s about right.",
+			  "date": "2019-02-14T20:56:17Z"
+			}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			assertJSONRoundtrip(t, tt.data, tt.json, &InstagramComment{})
 		})
 	}
 }

--- a/meta/instagram_test.go
+++ b/meta/instagram_test.go
@@ -103,7 +103,6 @@ func TestInstagramMediaJSON(t *testing.T) {
 					Latitude:  37.8029,
 					Longitude: -122.2721,
 				},
-				Likes: 1,
 				TaggedUsers: []InstagramTaggedUser{
 					{
 						Username: "rcarver",
@@ -111,6 +110,8 @@ func TestInstagramMediaJSON(t *testing.T) {
 						Y:        0.7938808374,
 					},
 				},
+				LikesCount:    1,
+				CommentsCount: 3,
 			},
 			json: `{
 			  "id": "1979320569926821011_11073382793",
@@ -130,14 +131,15 @@ func TestInstagramMediaJSON(t *testing.T) {
 			    "latitude": 37.8029,
 			    "longitude": -122.2721
 			  },
-			  "likes": 1,
 			  "tagged_users": [
 			    {
 			      "username": "rcarver",
 			      "x": 0.57568438,
 			      "y": 0.7938808374
 			    }
-			  ]
+			  ],
+			  "likes_count": 1,
+			  "comments_count": 3
 			}`,
 		},
 	}

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -102,7 +102,8 @@ type Image struct {
 
 // SrcSpecific contains source-specific metadata.
 type SrcSpecific struct {
-	Flickr *FlickrMedia `json:"flickr,omitempty"`
+	Flickr    *FlickrMedia    `json:"flickr,omitempty"`
+	Instagram *InstagramMedia `json:"instagram,omitempty"`
 }
 
 func (m Content) isZero() bool {


### PR DESCRIPTION
This creates the `InstagramMedia` data structure, and exposes it at `Meta.Srcs.Instagram`

It covers all of the data available in the `/users/self/media/recent` endpoint, while collapsing some duplicative data. Notably, that the caption is created by the same user as the post and at the same time. If this is an unrealistic assumption I'd love to know why - but it seems like it's just treating the caption as a special comment.