### PR TITLE
Clean up uri package file path handling

### DIFF
--- a/examples/index/main.go
+++ b/examples/index/main.go
@@ -42,12 +42,12 @@ func main() {
 }
 
 func buildIndex() (*index.Index, error) {
-	srcPath, err := uri.NewDirPath("/tmp/src")
+	srcPath, err := uri.ParseDir("/tmp/src")
 	if err != nil {
 		return nil, fmt.Errorf("Could not create src path: %s", err)
 	}
 
-	dstPath, err := uri.NewDirPath("/tmp/dst")
+	dstPath, err := uri.ParseDir("/tmp/dst")
 	if err != nil {
 		return nil, fmt.Errorf("Could not create dst path: %s", err)
 	}

--- a/uri/encoding_test.go
+++ b/uri/encoding_test.go
@@ -36,13 +36,13 @@ func TestURIJSON(t *testing.T) {
 			json: `"https://www.example.com"`,
 		},
 		{
-			desc: "FilePath zero value",
-			uri:  FilePath{},
+			desc: "Path zero value",
+			uri:  Path{},
 			json: `""`,
 		},
 		{
-			desc: "FilePath",
-			uri:  FilePath{URI{url: newURL("file:///path")}},
+			desc: "Path",
+			uri:  Path{URI{url: newURL("file:///path")}},
 			json: `"file:///path"`,
 		},
 	}

--- a/uri/fileuri.go
+++ b/uri/fileuri.go
@@ -10,33 +10,33 @@ import (
 	"strings"
 )
 
-// NewFilePath converts the path (abs or rel) to a file:// URI. If the path is
+// ParseFile converts the path (abs or rel) to a file:// URI. If the path is
 // empty or the input already contains a scheme (even file://) an error is
 // returned. The path of the returned URI is normalized via filepath.Clean.
-func NewFilePath(path string) (FilePath, error) {
+func ParseFile(path string) (Path, error) {
 	var err error
 	if path, err = cleanPath(path); err != nil {
-		return FilePath{zero}, err
+		return Path{zero}, err
 	}
 	url := &url.URL{Scheme: "file", Path: path}
-	return FilePath{URI{url: url}}, nil
+	return Path{URI{url: url}}, nil
 }
 
-// NewDirPath converts the path (abs or rel) to a file:// URI, assuming that
-// the path is intended to be a directory. Unlike files, directories always end
+// ParseDir converts the path (abs or rel) to a file:// URI, assuming that the
+// path is intended to be a directory. Unlike files, directories always end
 // with a slash ('/') in a URI. The path of the returned URI is normalized via
 // filepath.Clean.
-func NewDirPath(path string) (FilePath, error) {
+func ParseDir(path string) (Path, error) {
 	var err error
 	if path, err = cleanPath(path); err != nil {
-		return FilePath{zero}, err
+		return Path{zero}, err
 	}
 	// NOTE: ASCII-Only. Is that ok?
 	if path[len(path)-1:] != "/" {
 		path = path + "/"
 	}
 	url := &url.URL{Scheme: "file", Path: path}
-	return FilePath{URI{url: url}}, nil
+	return Path{URI{url: url}}, nil
 }
 
 func cleanPath(path string) (string, error) {
@@ -47,14 +47,14 @@ func cleanPath(path string) (string, error) {
 	return filepath.Clean(path), nil
 }
 
-// FilePath extends URI, adding special handling for filesystem paths. To
-// convert to standard URI, use filepath.URI.
-type FilePath struct {
+// Path wraps URI, adding special handling for filesystem paths. To
+// convert to standard URI, use path.URI.
+type Path struct {
 	URI
 }
 
 // IsAbs returns true if the path begins at root.
-func (u FilePath) IsAbs() bool {
+func (u Path) IsAbs() bool {
 	url := u.URL()
 	if url == nil {
 		return false
@@ -64,10 +64,10 @@ func (u FilePath) IsAbs() bool {
 
 var encodePlus = regexp.MustCompile(`\+`)
 
-// FilePath returns the absolute path for use on a filesystem. If the path
+// Filepath returns the absolute path for use on a filesystem. If the path
 // is not absolute or the URI is not a "file" scheme" an error is returned.
 // The resulting path is normalized via filepath.Clean.
-func (u FilePath) FilePath() (string, error) {
+func (u Path) Filepath() (string, error) {
 	if !u.IsAbs() {
 		return "", fmt.Errorf("URI is not absolute")
 	}

--- a/uri/fileuri.go
+++ b/uri/fileuri.go
@@ -19,7 +19,7 @@ func NewFilePath(path string) (FilePath, error) {
 		return FilePath{zero}, err
 	}
 	url := &url.URL{Scheme: "file", Path: path}
-	return FilePath{NewFromURL(url)}, nil
+	return FilePath{URI{url: url}}, nil
 }
 
 // NewDirPath converts the path (abs or rel) to a file:// URI, assuming that
@@ -36,7 +36,7 @@ func NewDirPath(path string) (FilePath, error) {
 		path = path + "/"
 	}
 	url := &url.URL{Scheme: "file", Path: path}
-	return FilePath{NewFromURL(url)}, nil
+	return FilePath{URI{url: url}}, nil
 }
 
 func cleanPath(path string) (string, error) {

--- a/uri/fileuri.go
+++ b/uri/fileuri.go
@@ -68,9 +68,6 @@ var encodePlus = regexp.MustCompile(`\+`)
 // is not absolute or the URI is not a "file" scheme" an error is returned.
 // The resulting path is normalized via filepath.Clean.
 func (u Path) Filepath() (string, error) {
-	if !u.IsAbs() {
-		return "", fmt.Errorf("URI is not absolute")
-	}
 	url := u.URL()
 	if url == nil {
 		return "", fmt.Errorf("missing url")

--- a/uri/fileuri_test.go
+++ b/uri/fileuri_test.go
@@ -20,6 +20,12 @@ func TestNewFileFromPath(t *testing.T) {
 			wantAbs: false,
 		},
 		{
+			desc:    "single part path",
+			path:    "path",
+			wantStr: "file://path",
+			wantAbs: false,
+		},
+		{
 			desc:    "relative path",
 			path:    "path/to/thing",
 			wantStr: "file://path/to/thing",
@@ -87,6 +93,12 @@ func TestNewDirFromPath(t *testing.T) {
 			desc:    "blank string",
 			path:    "   ",
 			wantStr: "file://./",
+			wantAbs: false,
+		},
+		{
+			desc:    "single part path",
+			path:    "path",
+			wantStr: "file://path/",
 			wantAbs: false,
 		},
 		{

--- a/uri/fileuri_test.go
+++ b/uri/fileuri_test.go
@@ -61,7 +61,7 @@ func TestNewFileFromPath(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		got, err := NewFilePath(tt.path)
+		got, err := ParseFile(tt.path)
 		if tt.wantErr {
 			if err == nil {
 				t.Errorf("%q NewFileFromPath() want error, got none", tt.desc)
@@ -138,7 +138,7 @@ func TestNewDirFromPath(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		got, err := NewDirPath(tt.path)
+		got, err := ParseDir(tt.path)
 		if tt.wantErr {
 			if err == nil {
 				t.Errorf("%q NewFileDir() want error, got none", tt.desc)
@@ -187,14 +187,14 @@ func TestIsAbs(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		path := FilePath{URI{url: tt.url}}
+		path := Path{URI{url: tt.url}}
 		got := path.IsAbs()
 		if got, want := got, tt.want; got != want {
 			t.Errorf("%q IsAbs() got %t want %t", tt.desc, got, want)
 		}
 	}
 }
-func TestFilePath(t *testing.T) {
+func TestFilepath(t *testing.T) {
 	newURL := func(str string) *url.URL {
 		u, err := url.Parse(str)
 		if err != nil {
@@ -260,18 +260,18 @@ func TestFilePath(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		path := FilePath{URI{url: tt.url}}
-		got, err := path.FilePath()
+		path := Path{URI{url: tt.url}}
+		got, err := path.Filepath()
 		if tt.wantErr {
 			if err == nil {
-				t.Errorf("%q FilePath() want error, got none", tt.desc)
+				t.Errorf("%q Filepath() want error, got none", tt.desc)
 			}
 		} else {
 			if err != nil {
-				t.Errorf("%q FilePath() got error, want none: %s", tt.desc, err)
+				t.Errorf("%q Filepath() got error, want none: %s", tt.desc, err)
 			}
 			if got, want := got, tt.want; got != want {
-				t.Errorf("%q FilePath()\ngot  %#v\nwant %#v", tt.desc, got, want)
+				t.Errorf("%q Filepath()\ngot  %#v\nwant %#v", tt.desc, got, want)
 			}
 		}
 	}

--- a/uri/fileuri_test.go
+++ b/uri/fileuri_test.go
@@ -204,9 +204,9 @@ func TestFilepath(t *testing.T) {
 			want: "/path",
 		},
 		{
-			desc:    "relative path",
-			path:    Path{TrustedNew("file://path")},
-			wantErr: true,
+			desc: "relative path",
+			path: Path{URI{url: &url.URL{Scheme: "file", Path: "path/to"}}},
+			want: "path/to",
 		},
 		{
 			desc:    "wrong scheme",

--- a/uri/fileuri_test.go
+++ b/uri/fileuri_test.go
@@ -11,26 +11,31 @@ func TestNewFileFromPath(t *testing.T) {
 		path    string
 		wantStr string
 		wantErr bool
+		wantAbs bool
 	}{
 		{
 			desc:    "blank string",
 			path:    "  ",
 			wantStr: "file://.",
+			wantAbs: false,
 		},
 		{
 			desc:    "relative path",
-			path:    "path",
-			wantStr: "file://path",
+			path:    "path/to/thing",
+			wantStr: "file://path/to/thing",
+			wantAbs: false,
 		},
 		{
 			desc:    "rooted path",
 			path:    "/abs/path",
 			wantStr: "file:///abs/path",
+			wantAbs: true,
 		},
 		{
 			desc:    "funky path",
 			path:    "/../abs/../path",
 			wantStr: "file:///path",
+			wantAbs: true,
 		},
 		{
 			desc:    "file scheme",
@@ -46,6 +51,7 @@ func TestNewFileFromPath(t *testing.T) {
 			desc:    "path with encoding problems",
 			path:    "/Photos Library.photoslibrary/Thumbnails/2015/09/23/20150923-010213/TqFU0duZTV+culxTIy%oVA/thumb_IMG_7220.jpg",
 			wantStr: "file:///Photos%20Library.photoslibrary/Thumbnails/2015/09/23/20150923-010213/TqFU0duZTV+culxTIy%25oVA/thumb_IMG_7220.jpg",
+			wantAbs: true,
 		},
 	}
 	for _, tt := range tests {
@@ -62,6 +68,9 @@ func TestNewFileFromPath(t *testing.T) {
 			if gotStr := got.String(); gotStr != tt.wantStr {
 				t.Errorf("%q NewFileFromPath() String()\ngot  %#v\nwant %#v", tt.desc, gotStr, tt.wantStr)
 			}
+			if got, want := got.IsAbs(), tt.wantAbs; got != want {
+				t.Errorf("%q IsAbs got %t want %t", tt.desc, got, want)
+			}
 		}
 	}
 }
@@ -72,36 +81,43 @@ func TestNewDirFromPath(t *testing.T) {
 		path    string
 		wantStr string
 		wantErr bool
+		wantAbs bool
 	}{
 		{
 			desc:    "blank string",
 			path:    "   ",
 			wantStr: "file://./",
+			wantAbs: false,
 		},
 		{
 			desc:    "relative path without trailing slash",
-			path:    "path",
-			wantStr: "file://path/",
+			path:    "path/to/thing",
+			wantStr: "file://path/to/thing/",
+			wantAbs: false,
 		},
 		{
 			desc:    "relative path with trailing slash",
-			path:    "path/",
-			wantStr: "file://path/",
+			path:    "path/to/",
+			wantStr: "file://path/to/",
+			wantAbs: false,
 		},
 		{
 			desc:    "absolute path without trailing slash",
 			path:    "/abs/path",
 			wantStr: "file:///abs/path/",
+			wantAbs: true,
 		},
 		{
 			desc:    "absolute path with trailing slash",
 			path:    "/abs/path/",
 			wantStr: "file:///abs/path/",
+			wantAbs: true,
 		},
 		{
 			desc:    "funky path",
-			path:    "/../abs/../path",
-			wantStr: "file:///path/",
+			path:    "/../abs/../path/to",
+			wantStr: "file:///path/to/",
+			wantAbs: true,
 		},
 		{
 			desc:    "file scheme",
@@ -122,6 +138,9 @@ func TestNewDirFromPath(t *testing.T) {
 			}
 			if gotStr := got.String(); gotStr != tt.wantStr {
 				t.Errorf("%q NewFileDir() String() got %#v, want %#v", tt.desc, gotStr, tt.wantStr)
+			}
+			if got, want := got.IsAbs(), tt.wantAbs; got != want {
+				t.Errorf("%q IsAbs got %t want %t", tt.desc, got, want)
 			}
 		}
 	}

--- a/uri/fileuri_test.go
+++ b/uri/fileuri_test.go
@@ -229,9 +229,9 @@ func TestFilepath(t *testing.T) {
 			want: "/path with space",
 		},
 		{
-			desc:    "path has invalid encoding",
-			path:    Path{URI{url: &url.URL{Scheme: "file", Path: "file:///path%2with%20invalid"}}},
-			wantErr: true,
+			desc: "path has invalid encoding",
+			path: Path{URI{url: &url.URL{Scheme: "file", Path: "/path%2with%20invalid"}}},
+			want: "/path%2with%20invalid",
 		},
 		{
 			desc: "path has funky references",


### PR DESCRIPTION
This cleans up some rough edges on file path handling in the `uri` package.

Naming:

* `NewFilePath` to `ParseFile`
* `NewDirPath` to `ParseDir`
* `FilePath{}` to `Path{}`
* `FilePath()` to `Filepath()`

Fixed parsing of relative URIs which got mis-interpreted as absolute urls. 