### PR TITLE
Portable readme

### DIFF
--- a/dst/files/read.go
+++ b/dst/files/read.go
@@ -2,6 +2,7 @@
 package files
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -9,8 +10,27 @@ import (
 	"runtime"
 )
 
-// Read returns a file contained in this package.
-func Read(name string) ([]byte, error) {
+// Read returns file contents.
+var Read readFunc = defaultRead
+
+type readFunc func(string) ([]byte, error)
+
+// List returns a list of the non-go file names contained in this package.
+func List() []string {
+	out := make([]string, 0)
+	files, err := filepath.Glob(path.Join(getPath(), "*"))
+	if err != nil {
+		panic(fmt.Sprintf("could not glob files: %s", err))
+	}
+	for _, f := range files {
+		if path.Ext(f) != ".go" {
+			out = append(out, path.Base(f))
+		}
+	}
+	return out
+}
+
+func defaultRead(name string) ([]byte, error) {
 	path := filepath.Join(getPath(), name)
 	f, err := os.Open(path)
 	if err != nil {

--- a/dst/layout_test.go
+++ b/dst/layout_test.go
@@ -64,17 +64,29 @@ func TestFilesystemLayout(t *testing.T) {
 	}
 }
 
-func TestFilesystemLayoutFiles(t *testing.T) {
-	layout := NewFilesystemLayout()
-	files := layout.Files()
-	if len(files) == 0 {
-		t.Fatalf("expect files")
+func TestFilesytemLayoutFiles(t *testing.T) {
+	tests := []struct {
+		desc   string
+		layout Layout
+	}{
+		{
+			desc:   "default",
+			layout: NewFilesystemLayout(),
+		},
 	}
-	file := files[0]
-	if got, want := file.URI, uri.TrustedNew("README.txt"); !got.Equal(want) {
-		t.Errorf("URI got %s want %s", got, want)
-	}
-	if len(file.Data) == 0 {
-		t.Errorf("File has no data")
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			files := tt.layout.Files()
+			if len(files) == 0 {
+				t.Fatalf("expect files")
+			}
+			file := files[0]
+			if got, want := file.URI, uri.TrustedNew("README.txt"); !got.Equal(want) {
+				t.Errorf("URI got %s want %s", got, want)
+			}
+			if len(file.Data) == 0 {
+				t.Errorf("File has no data")
+			}
+		})
 	}
 }


### PR DESCRIPTION
This allows the destination README to be provided by something other than a file on disk, to support building a binary distribution using this library.