### PR TITLE
fix path escaping

### DIFF
--- a/uri/path.go
+++ b/uri/path.go
@@ -46,7 +46,7 @@ func ParseFileURI(u URI) (Path, error) {
 		if url.Host != "" {
 			return Path{}, fmt.Errorf("host must be empty")
 		}
-		return ParsePath(url.EscapedPath())
+		return ParsePath(url.Path)
 	}
 	str := u.String()
 	str = strings.TrimPrefix(str, "file://")
@@ -119,11 +119,11 @@ func (p Path) URL() *url.URL {
 // Filepath returns a clean, absolute path on the filesystem.
 func (p Path) Filepath() string {
 	raw := p.RawPath
-	un, err := url.QueryUnescape(raw)
-	if err != nil {
-		return filepath.Clean(raw)
+	un, err := url.PathUnescape(raw)
+	if err == nil {
+		return filepath.Clean(un)
 	}
-	return filepath.Clean(un)
+	return filepath.Clean(raw)
 }
 
 func cleanAbsPath(raw string) (string, error) {

--- a/uri/path_test.go
+++ b/uri/path_test.go
@@ -37,16 +37,16 @@ func TestPathRoundtrip(t *testing.T) {
 			wantFilepath: "/tmp/path",
 		},
 		{
-			desc:         "encoded path",
-			raw:          "/tmp/file%20with%20space",
-			wantURI:      "file:///tmp/file%20with%20space",
-			wantFilepath: "/tmp/file with space",
-		},
-		{
 			desc:         "badly encoded path",
 			raw:          "/tmp/file%2with%20space",
 			wantURI:      "file:///tmp/file%2with%20space",
 			wantFilepath: "/tmp/file%2with%20space",
+		},
+		{
+			desc:         "complex path",
+			raw:          "/Users/rcarver/Pictures/Photos Library.photoslibrary/Masters/2016/11/28/20161128-020053/ITG2jAEkQ9eYhgdsN+GW3g/L1007834.jpg",
+			wantURI:      "file:///Users/rcarver/Pictures/Photos%20Library.photoslibrary/Masters/2016/11/28/20161128-020053/ITG2jAEkQ9eYhgdsN+GW3g/L1007834.jpg",
+			wantFilepath: "/Users/rcarver/Pictures/Photos Library.photoslibrary/Masters/2016/11/28/20161128-020053/ITG2jAEkQ9eYhgdsN+GW3g/L1007834.jpg",
 		},
 		{
 			desc:         "complex path with invalid encoding",
@@ -274,7 +274,7 @@ func TestParseFileURI(t *testing.T) {
 			desc: "encoded path",
 			uri:  newURI("file:///tmp/file%20with%20space"),
 			want: Path{
-				RawPath: "/tmp/file%20with%20space",
+				RawPath: "/tmp/file with space",
 			},
 		},
 		{
@@ -282,6 +282,13 @@ func TestParseFileURI(t *testing.T) {
 			uri:  newURI("file:///tmp/file%2with%20space"),
 			want: Path{
 				RawPath: "/tmp/file%2with%20space",
+			},
+		},
+		{
+			desc: "complex path with valid encoding",
+			uri:  newURI("file:///Users/rcarver/Pictures/Photos%20Library.photoslibrary/Masters/2016/11/28/20161128-020053/ITG2jAEkQ9eYhgdsN+GW3g/L1007834.jpg"),
+			want: Path{
+				RawPath: "/Users/rcarver/Pictures/Photos Library.photoslibrary/Masters/2016/11/28/20161128-020053/ITG2jAEkQ9eYhgdsN+GW3g/L1007834.jpg",
 			},
 		},
 		{
@@ -510,6 +517,13 @@ func TestPathFilepath(t *testing.T) {
 				RawPath: "/tmp/file%2with%20space",
 			},
 			want: "/tmp/file%2with%20space",
+		},
+		{
+			desc: "complex path with invalid encoding",
+			path: Path{
+				RawPath: "/Users/rcarver/Pictures/Photos Library.photoslibrary/Masters/2016/11/28/20161128-020053/ITG2jAEkQ9eYhgdsN+GW3g/L1007834.jpg",
+			},
+			want: "/Users/rcarver/Pictures/Photos Library.photoslibrary/Masters/2016/11/28/20161128-020053/ITG2jAEkQ9eYhgdsN+GW3g/L1007834.jpg",
 		},
 		{
 			desc: "complex path with invalid encoding",

--- a/uri/path_test.go
+++ b/uri/path_test.go
@@ -519,7 +519,7 @@ func TestPathFilepath(t *testing.T) {
 			want: "/tmp/file%2with%20space",
 		},
 		{
-			desc: "complex path with invalid encoding",
+			desc: "complex path",
 			path: Path{
 				RawPath: "/Users/rcarver/Pictures/Photos Library.photoslibrary/Masters/2016/11/28/20161128-020053/ITG2jAEkQ9eYhgdsN+GW3g/L1007834.jpg",
 			},


### PR DESCRIPTION
This fixes a bad round-trip from URI to file path. Changes:

1. Use PathUnescape instead of QueryUnescape so +'s aren't turned into spaces
2. When converting from a URI, don't escape the path - use it as-is